### PR TITLE
Set updatecenter url

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/dogu-build-lib@a9f0e688', 'github.com/cloudogu/zalenium-build-lib@d8b74327']) _
+@Library(['github.com/cloudogu/dogu-build-lib@1e5e2a63', 'github.com/cloudogu/zalenium-build-lib@30923630']) _
 import com.cloudogu.ces.dogubuildlib.*
 
 node('vagrant') {

--- a/dogu.json
+++ b/dogu.json
@@ -30,6 +30,13 @@
   "ServiceAccounts": [{
     "Type": "postgresql"
   }],
+  "Configuration": [
+    {
+    "Name": "sonar.updatecenter.url",
+    "Description": "Set UpdateCenter URL",
+    "Optional": true
+    }
+  ],
   "HealthChecks": [{
     "Type": "tcp",
     "Port": 9000

--- a/integrationTests/cas-rest.spec.js
+++ b/integrationTests/cas-rest.spec.js
@@ -15,16 +15,6 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 let driver;
 
-beforeEach(async () => {
-    driver = utils.createDriver(webdriver);
-    await driver.manage().window().maximize();
-});
-
-afterEach(async () => {
-    await driver.quit();
-});
-
-
 
 describe('cas rest basic authentication', () => {
 
@@ -37,6 +27,7 @@ describe('cas rest basic authentication', () => {
 
     /*login -> click on username -> configure -> show api token*/
     test('authentication with API key', async () => {
+        driver = utils.createDriver(webdriver);
 		//Create user Token
         await driver.get(utils.getCasUrl(driver));
         await utils.login(driver);
@@ -59,7 +50,9 @@ describe('cas rest basic authentication', () => {
 		await driver.get(config.baseUrl + config.sonarContextPath + "/account/security");
         await driver.wait(until.elementLocated(By.className("js-revoke-token-form")), 5000);
         await driver.findElement(By.className("js-revoke-token-form")).click(); // Click to delete
-		await driver.findElement(By.className("js-revoke-token-form")).click(); // Click to confirm deletion
+        await driver.findElement(By.className("js-revoke-token-form")).click(); // Click to confirm deletion
+
+        await driver.quit();
     });
 
     test('rest - user attributes', async () => {
@@ -76,6 +69,7 @@ describe('cas rest basic authentication', () => {
     });
 
     test('rest - user is administrator', async () => {
+        driver = utils.createDriver(webdriver);
         await driver.sleep(waitInterval);
         const response = await request(config.baseUrl)
             .get(config.sonarContextPath + "/api/users/search/json")
@@ -87,6 +81,7 @@ describe('cas rest basic authentication', () => {
 
         const userObject = JSON.parse(response["request"]["req"]["res"]["text"]).users[0];
         expectations.expectStateAdmin(userObject);
+        await driver.quit();
     });
 
 });

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -125,6 +125,17 @@ function sql(){
   return $?
 }
 
+function configureUpdatecenterUrl() {
+# remove updatecenter url configuration, if existent
+sed -i '/sonar.updatecenter.url=/d' ${SONAR_PROPERTIESFILE}
+# set updatecenter url if configured in registry
+if doguctl config sonar.updatecenter.url > /dev/null; then
+  updatecenterUrl=$(doguctl config sonar.updatecenter.url)
+  echo "Setting sonar.updatecenter.url to ${updatecenterUrl}"
+  echo sonar.updatecenter.url="${updatecenterUrl}" >> ${SONAR_PROPERTIESFILE}
+fi
+}
+
 function firstSonarStart() {
   echo "first start of SonarQube dogu"
 	# prepare config
@@ -290,6 +301,7 @@ else
   subsequentSonarStart
 fi
 
+configureUpdatecenterUrl
 
 doguctl state "ready"
 # fire it up


### PR DESCRIPTION
The SonarQube UpdateCenter URL is now configurable via the `sonar.updatecenter.url` registry entry.
Resolves #15 