### PR TITLE
Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ EXPOSE 9000
 
 USER sonar
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ]
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ] && [ $(doguctl state) == "ready" ]
 
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ EXPOSE 9000
 
 USER sonar
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=600s --retries=10 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ]
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ]
 
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,6 @@ EXPOSE 9000
 
 USER sonar
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=600s --retries=10 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ]
+
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ EXPOSE 9000
 
 USER sonar
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ] && [ $(doguctl state) == "ready" ]
+HEALTHCHECK CMD [ $(curl --silent --fail -u sonarqubedoguadmin:$(doguctl config -e dogu_admin_password) http://localhost:9000/sonar/api/system/health | jq -r '.health') = "GREEN" ] && [ $(doguctl state) == "ready" ] && [ $(doguctl healthy sonar; EXIT_CODE=$?; echo ${EXIT_CODE}) == 0 ]
 
 CMD ["/startup.sh"]


### PR DESCRIPTION
Add a docker healthcheck to the dogu to have a more transparent health status.
Resolves #18 