### PR TITLE
Save extensions folder in volume

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -26,6 +26,13 @@
     "Owner": "1000",
     "Group": "1000",
     "NeedsBackup": false
+  },
+  {
+    "Name": "extensions",
+    "Path": "/opt/sonar/extensions",
+    "Owner": "1000",
+    "Group": "1000",
+    "NeedsBackup": true
   }],
   "ServiceAccounts": [{
     "Type": "postgresql"

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -23,6 +23,12 @@ echo "Running post-upgrade script..."
 
 doguctl config post_upgrade_running true
 
+if [[ ${FROM_VERSION} == *"6.7.6-1"* ]] && [[ ${TO_VERSION} == *"6.7.6"* ]]; then
+  mkdir -p /opt/sonar/extensions
+  cp -R /opt/sonar/data/extensions/* /opt/sonar/extensions/
+  rm -rf /opt/sonar/data/extensions
+fi
+
 if [[ ${FROM_VERSION} == *"5.6.6"* ]]; then
   echo "You have upgraded from SonarQube 5.6.6. This may lead to unexpected behavior!"
   echo "See https://docs.sonarqube.org/latest/setup/upgrading/"

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -66,6 +66,11 @@ if [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   # The temporary admin user is not removed; this will be done at the end of firstSonarStart() in the sonar 6.7.x dogu
 fi
 
+if [[ ${FROM_VERSION} == *"6.7.6-1"* ]] && [[ ${TO_VERSION} == *"6.7.6-2"* ]]; then
+  mkdir /opt/sonar/data/extensions
+  cp -R /opt/sonar/extensions/* /opt/sonar/data/extensions/
+fi
+
 
 
 


### PR DESCRIPTION
Add new volume for /opt/sonar/extensions folder to save e.g. the installed
plugins from beeing deleted when the container is rebuild (for example when
it is restored from a backup).
Resolves #20