### PR TITLE
Save all plugins at 5.6.7 to 6.7.6 upgrade

### DIFF
--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -132,7 +132,7 @@ if [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   set_successful_first_start_flag
 fi
 
-if [[ ${FROM_VERSION} == *"6.7.6-1"* ]]; then
+if [[ ${FROM_VERSION} == *"6.7.6-1"* ]] || [[ ${FROM_VERSION} == *"5.6"* ]]; then
   # grant further permissions to CES admin group via API
   # TODO: Extract grant_permission_to_group_via_rest_api function from startup.sh into util.sh and use it instead
   CES_ADMIN_GROUP=$(doguctl config --global admin_group)

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -26,7 +26,7 @@ function install_plugin_via_api() {
   PLUGIN=${1}
   INSTALL_RESPONSE=$(curl ${CURL_LOG_LEVEL} -u admin:admin -X POST http://localhost:9000/sonar/api/plugins/install?key="${PLUGIN}")
   # check response for error messages
-  if ! [[ -z ${INSTALL_RESPONSE} ]]; then
+  if [[ -n ${INSTALL_RESPONSE} ]]; then
     ERROR_MESSAGE=$(echo "${INSTALL_RESPONSE}"|jq '.errors[0]'|jq '.msg')
     if [[ ${ERROR_MESSAGE} == *"No plugin with key '${PLUGIN}' or plugin '${PLUGIN}' is already installed in latest version"* ]]; then
       echo "Plugin ${PLUGIN} is not available at all or already installed in latest version."
@@ -51,7 +51,7 @@ function reinstall_plugins() {
     done
   done <<< "$(doguctl config install_plugins)"
 
-  if ! [[ -z ${FAILED_PLUGIN_NAMES} ]]; then
+  if [[ -n ${FAILED_PLUGIN_NAMES} ]]; then
     echo "The following plugins could not have been re-installed: ${FAILED_PLUGIN_NAMES}"
   fi
 }

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -63,6 +63,7 @@ echo "Running post-upgrade script..."
 
 doguctl config post_upgrade_running true
 
+# Migrate saved extensions folder to its own volume
 if [[ ${FROM_VERSION} == *"6.7.6-1"* ]]; then
   mkdir -p /opt/sonar/extensions
   cp -R /opt/sonar/data/extensions/* /opt/sonar/extensions/

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -60,9 +60,10 @@ if [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   echo "Setting correct owner for data folder..."
   chown -R sonar:sonar "/var/lib/sonar"
 
-  # The temporary admin user is not removed; this will be done at the end of firstSonarStart() in the sonar 6.7.x dogu
+  # The temporary admin user is not removed; this will be done at the end of the post-upgrade script in the sonar 6.7.x dogu
 fi
 
+# Save extensions folder as it henceforth gets its own volume
 if [[ ${FROM_VERSION} == *"6.7.6-1"* ]]; then
   mkdir /opt/sonar/data/extensions
   cp -R /opt/sonar/extensions/* /opt/sonar/data/extensions/

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -44,15 +44,14 @@ if [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   echo "Creating temporary ${TEMPORARY_ADMIN_USER} user..."
   add_temporary_admin_user "${TEMPORARY_ADMIN_USER}"
 
-  echo "Getting plugins which are not up-to-date..."
-  AVAILABLE_PLUGIN_UPDATES=$(curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X GET localhost:9000/sonar/api/plugins/updates | jq '.plugins' | jq '.[]' | jq -r '.key')
-  echo "The following plugins are not up-to-date. They will be removed and re-installed after dogu upgrade:"
+  echo "Getting all installed..."
+  AVAILABLE_PLUGIN_UPDATES=$(curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X GET localhost:9000/sonar/api/plugins/installed | jq '.plugins' | jq '.[]' | jq -r '.key')
+  echo "The following plugins are installed. They will be removed and re-installed after dogu upgrade:"
   echo "${AVAILABLE_PLUGIN_UPDATES}"
   SAVED_PLUGIN_NAMES=""
-  # remove them
+  # TODO: Do not remove them as they will be removed automatically when the plugins folder gets moved to its own volume??
   while read -r PLUGIN; do
-    echo "Removing plugin ${PLUGIN}..."
-    curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X POST "localhost:9000/sonar/api/plugins/uninstall?key=${PLUGIN}"
+    #curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X POST "localhost:9000/sonar/api/plugins/uninstall?key=${PLUGIN}"
     SAVED_PLUGIN_NAMES+=${PLUGIN},
   done <<< "${AVAILABLE_PLUGIN_UPDATES}"
 

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -44,22 +44,20 @@ if [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   echo "Creating temporary ${TEMPORARY_ADMIN_USER} user..."
   add_temporary_admin_user "${TEMPORARY_ADMIN_USER}"
 
-  echo "Getting all installed..."
-  AVAILABLE_PLUGIN_UPDATES=$(curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X GET localhost:9000/sonar/api/plugins/installed | jq '.plugins' | jq '.[]' | jq -r '.key')
-  echo "The following plugins are installed. They will be removed and re-installed after dogu upgrade:"
-  echo "${AVAILABLE_PLUGIN_UPDATES}"
+  echo "Getting all installed plugins..."
+  INSTALLED_PLUGINS=$(curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X GET localhost:9000/sonar/api/plugins/installed | jq '.plugins' | jq '.[]' | jq -r '.key')
+  echo "The following plugins are installed. They will be re-installed after dogu upgrade:"
+  echo "${INSTALLED_PLUGINS}"
   SAVED_PLUGIN_NAMES=""
-  # TODO: Do not remove them as they will be removed automatically when the plugins folder gets moved to its own volume??
   while read -r PLUGIN; do
-    #curl --silent --fail -u "${TEMPORARY_ADMIN_USER}":admin -X POST "localhost:9000/sonar/api/plugins/uninstall?key=${PLUGIN}"
     SAVED_PLUGIN_NAMES+=${PLUGIN},
-  done <<< "${AVAILABLE_PLUGIN_UPDATES}"
+  done <<< "${INSTALLED_PLUGINS}"
 
   echo "Saving plugin names to registry..."
   doguctl config install_plugins "${SAVED_PLUGIN_NAMES}"
 
   # Changing owner of data folder, because SonarQube 6.7 dogu user is 'sonar' and not root any more
-  echo "Setting correct owner for data folder"
+  echo "Setting correct owner for data folder..."
   chown -R sonar:sonar "/var/lib/sonar"
 
   # The temporary admin user is not removed; this will be done at the end of firstSonarStart() in the sonar 6.7.x dogu

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -227,8 +227,8 @@ function subsequentSonarStart() {
 if [[ -e ${SONARQUBE_HOME}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar ]]; then
   echo "Moving cas plugin to plugins folder..."
   mkdir -p "${SONARQUBE_HOME}/extensions/plugins"
-  if ls ${SONARQUBE_HOME}/extensions/plugins/sonar-cas-plugin-*.jar 1> /dev/null 2>&1; then
-    rm ${SONARQUBE_HOME}/extensions/plugins/sonar-cas-plugin-*.jar
+  if ls "${SONARQUBE_HOME}"/extensions/plugins/sonar-cas-plugin-*.jar 1> /dev/null 2>&1; then
+    rm "${SONARQUBE_HOME}"/extensions/plugins/sonar-cas-plugin-*.jar
   fi
   mv "${SONARQUBE_HOME}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar" "${SONARQUBE_HOME}/extensions/plugins/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar"
 fi

--- a/resources/upgrade-notification.sh
+++ b/resources/upgrade-notification.sh
@@ -13,5 +13,5 @@ if [[ ${FROM_VERSION} == *"5.6.6"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   exit 1
 elif [[ ${FROM_VERSION} == *"5.6.7"* ]] && [[ ${TO_VERSION} == *"6.7."* ]]; then
   echo "You are upgrading your SonarQube instance from 5.6.7 to 6.7.x LTS. Please consider backing up your SonarQube database. Upgrade problems are rare, but you'll want the backup if anything does happen."
-  echo "If you are using plugins which are not up-to-date, they will be updated during the upgrade process."
+  echo "The currently installed plugins will be re-installed in SonarQube 6.7, potentially in a newer version than they are installed now. As not all plugins which have been available in SonarQube 5.6 are also available in SonarQube 6.7, you should check the log output for plugins which could not be re-installed."
 fi


### PR DESCRIPTION
At upgrade from version 5.6.7 to 6.7.6, the names of the plugins which were installed in the 5.6.7 sonar dogu are saved to registry. Then the post-upgrade script reads those names and tries to install the plugins in the 6.7.6 sonar dogu. This now applies to all plugins and not just outdated ones.
Resolves #26 