### PR TITLE
Bugfix/30 handle admin group name change gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# ignore IDEA stuff
+.idea/
+out/
+.idea_modules/
+*.iml
+
+# ignore VS code stuff
+.vscode/*

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -117,6 +117,8 @@ function create_user_group_via_rest_api() {
   AUTH_USER=$3
   AUTH_PASSWORD=$4
   curl ${CURL_LOG_LEVEL} --fail -u "${AUTH_USER}":"${AUTH_PASSWORD}" -X POST "http://localhost:9000/sonar/api/user_groups/create?name=${NAME}&description=${DESCRIPTION}"
+  # for unknown reasons the curl call prints the resulting JSON without newline to stdout which disturbs logging
+  printf "\\n"
 }
 
 function grant_permission_to_group_via_rest_api() {

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -160,7 +160,7 @@ function grant_admin_group_permissions() {
 }
 
 function run_first_start_tasks() {
-  echo  "Adding CES admin group..."
+  echo  "Adding CES admin group '${CES_ADMIN_GROUP}'..."
   create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
   grant_admin_group_permissions ${CES_ADMIN_GROUP}
@@ -227,7 +227,7 @@ function subsequentSonarStart() {
   # Creating CES admin group if not existent or if it has changed
   ADMIN_GROUP_COUNT=$(curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X GET "http://localhost:9000/sonar/api/user_groups/search?q=${CES_ADMIN_GROUP}" | jq '.paging' | jq -r '.total')
   if [[ ${ADMIN_GROUP_COUNT} == 0 ]]; then
-    echo  "Adding CES admin group..."
+    echo  "Adding CES admin group '${CES_ADMIN_GROUP}'..."
     create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
     grant_admin_group_permissions ${CES_ADMIN_GROUP}
@@ -235,7 +235,7 @@ function subsequentSonarStart() {
 }
 
 function remove_permissions_from_last_admin_group() {
-    printf "Remove admin privileges from previous CES admin group %s...\\n" ${CES_ADMIN_GROUP_LAST}
+    printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${CES_ADMIN_GROUP_LAST}
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
 
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "admin" "${DOGU_ADMIN}" "${dogu_admin_password}"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -29,7 +29,7 @@ MAIL_ADDRESS=$(doguctl config --default "sonar@${DOMAIN}" --global mail_address)
 QUALITY_PROFILE_DIR="/var/lib/qualityprofiles"
 CURL_LOG_LEVEL="--silent"
 HEALTH_TIMEOUT=600
-PERMISSIONS="admin profileadmin gateadmin provisioning"
+ADMIN_PERMISSIONS="admin profileadmin gateadmin provisioning"
 
 function import_quality_profiles_if_present {
   AUTH_USER=$1
@@ -154,11 +154,11 @@ function set_updatecenter_url_if_configured_in_registry() {
 function grant_admin_group_permissions() {
     local admin_group=$1
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
-    printf "\\nAdding admin privileges to CES admin group...\\n"
-    for permission in $PERMISSIONS
+    printf "Adding admin privileges to CES admin group...\\n"
+    for permission in ${ADMIN_PERMISSIONS}
     do
-      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP}
-      grant_permission_to_group_via_rest_api "${admin_group}" "$permission" "${DOGU_ADMIN}" "${dogu_admin_password}"
+      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${admin_group}
+      grant_permission_to_group_via_rest_api "${admin_group}" "${permission}" "${DOGU_ADMIN}" "${dogu_admin_password}"
     done
 }
 
@@ -238,16 +238,17 @@ function subsequentSonarStart() {
 }
 
 function remove_permissions_from_last_admin_group() {
-    printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${CES_ADMIN_GROUP_LAST}
+    local admin_group=${CES_ADMIN_GROUP_LAST}
+    printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${admin_group}
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
-    for permission in $PERMISSIONS
+    for permission in ${ADMIN_PERMISSIONS}
     do
-      printf "remove permission '%s' from group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
-      remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "$permission" "${DOGU_ADMIN}" "${dogu_admin_password}"
+      printf "remove permission '%s' from group '%s'...\\n" ${permission} ${admin_group}
+      remove_permission_of_group_via_rest_api "${admin_group}" "${permission}" "${DOGU_ADMIN}" "${dogu_admin_password}"
     done
 }
 
-# It returns 0 if the admin group names differs from eachother. Otherwise, it returns the value 1 if both admin group names have the same value.
+# It returns 0 if the admin group names differs from each other. Otherwise, it returns the value 1.
 function has_admin_group_changed() {
     return $(expr "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST")
 }

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -283,7 +283,7 @@ while [[ "$(doguctl config post_upgrade_running)" == "true" ]]; do
 done
 
 # check whether firstSonarStart has already been performed
-if [ "$(doguctl config successfulFirstStart)" != "true" ]; then
+if [[ "$(doguctl config successfulFirstStart)" != "true" ]]; then
   firstSonarStart
 else
   subsequentSonarStart

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -157,7 +157,7 @@ function grant_admin_group_permissions() {
     printf "\\nAdding admin privileges to CES admin group...\\n"
     for permission in $PERMISSIONS
     do
-      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
+      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP}
       grant_permission_to_group_via_rest_api "${admin_group}" "$permission" "${DOGU_ADMIN}" "${dogu_admin_password}"
     done
 }
@@ -248,7 +248,7 @@ function remove_permissions_from_last_admin_group() {
 }
 
 # It returns 0 if the admin group names differs from eachother. Otherwise, it returns the value 1 if both admin group names have the same value.
-function hasAdminGroupChanged() {
+function has_admin_group_changed() {
     return $(expr "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST")
 }
 
@@ -308,7 +308,7 @@ else
   subsequentSonarStart
 fi
 
-if hasAdminGroupChanged
+if has_admin_group_changed
 then
     remove_permissions_from_last_admin_group
 else

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -244,6 +244,11 @@ function remove_permissions_from_last_admin_group() {
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "provisioning" "${DOGU_ADMIN}" "${dogu_admin_password}"
 }
 
+# returns value 1 if both admin group names have the same value. Otherwise, it returns 0
+function hasAdminGroupChanged() {
+    return $(expr "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST")
+}
+
 ### End of function declarations, work is done now
 
 if [[ -e ${SONARQUBE_HOME}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar ]]; then
@@ -300,11 +305,11 @@ else
   subsequentSonarStart
 fi
 
-if [[ ${CES_ADMIN_GROUP} == ${CES_ADMIN_GROUP_LAST} ]];
+if hasAdminGroupChanged
 then
-    echo "Did not detect a change of the admin group. Continue as usual..."
-else
     remove_permissions_from_last_admin_group
+else
+    echo "Did not detect a change of the admin group. Continue as usual..."
 fi
 update_last_admin_group_in_registry ${CES_ADMIN_GROUP}
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -221,6 +221,16 @@ function subsequentSonarStart() {
   fi
 }
 
+function getLastAdminGroupOrGlobalAdminGroup() {
+    if CES_ADMIN_GROUP_LAST=$(doguctl config admin_group_last) ;
+    then
+        return ${CES_ADMIN_GROUP_LAST}
+    else
+        # this group name is used either way to check if it is equal with the global admin group
+        # instead of unnecessarily check for empty strings we return a valid value for the equal-check
+        return $(doguctl config --global admin_group)
+    fi
+}
 
 
 ### End of function declarations, work is done now
@@ -277,6 +287,13 @@ if [ "$(doguctl config successfulFirstStart)" != "true" ]; then
   firstSonarStart
 else
   subsequentSonarStart
+fi
+
+if [[ ${CES_ADMIN_GROUP} == $(getLastAdminGroupOrGlobalAdminGroup) ]];
+then
+    echo "Did not detect a change of the admin group. Continue as usual"
+else
+    remove_permissions_from_last_admin_group
 fi
 
 echo "Setting sonar.core.serverBaseURL..."

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -153,8 +153,8 @@ function set_updatecenter_url_if_configured_in_registry() {
 
 function grant_admin_group_permissions() {
     local admin_group=$1
+    local dogu_admin_password=$(doguctl config -e dogu_admin_password)
     printf "\\nAdding admin privileges to CES admin group...\\n"
-
     for permission in $PERMISSIONS
     do
       printf "grant permission '%s' to group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
@@ -240,7 +240,6 @@ function subsequentSonarStart() {
 function remove_permissions_from_last_admin_group() {
     printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${CES_ADMIN_GROUP_LAST}
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
-
     for permission in $PERMISSIONS
     do
       printf "remove permission '%s' from group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
@@ -248,7 +247,7 @@ function remove_permissions_from_last_admin_group() {
     done
 }
 
-# returns value 1 if both admin group names have the same value. Otherwise, it returns 0
+# It returns 0 if the admin group names differs from eachother. Otherwise, it returns the value 1 if both admin group names have the same value.
 function hasAdminGroupChanged() {
     return $(expr "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST")
 }
@@ -315,6 +314,7 @@ then
 else
     echo "Did not detect a change of the admin group. Continue as usual..."
 fi
+
 update_last_admin_group_in_registry ${CES_ADMIN_GROUP}
 
 echo "Setting sonar.core.serverBaseURL..."

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -230,23 +230,10 @@ function subsequentSonarStart() {
   fi
 }
 
-function getLastAdminGroupOrGlobalAdminGroup() {
-    local admin_group_last=""
-
-    if admin_group_last=$(doguctl config admin_group_last) ;
-    then
-        return ${admin_group_last}
-    else
-        # this group name is used either way to check if it is equal with the global admin group
-        # instead of unnecessarily check for empty strings we return a valid value for the equal-check
-        return $(doguctl config --global admin_group)
-    fi
-}
-
 function remove_permissions_from_last_admin_group() {
     printf "\\nRemove admin privileges from previous CES admin group %s...\\n" ${CES_ADMIN_GROUP_LAST}
-
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
+
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "admin" "${DOGU_ADMIN}" "${dogu_admin_password}"
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "profileadmin" "${DOGU_ADMIN}" "${dogu_admin_password}"
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "gateadmin" "${DOGU_ADMIN}" "${dogu_admin_password}"
@@ -311,7 +298,7 @@ fi
 
 if [[ ${CES_ADMIN_GROUP} == ${CES_ADMIN_GROUP_LAST} ]];
 then
-    echo "Did not detect a change of the admin group. Continue as usual"
+    echo "Did not detect a change of the admin group. Continue as usual..."
 else
     remove_permissions_from_last_admin_group
 fi

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -235,7 +235,7 @@ function subsequentSonarStart() {
 }
 
 function remove_permissions_from_last_admin_group() {
-    printf "\\nRemove admin privileges from previous CES admin group %s...\\n" ${CES_ADMIN_GROUP_LAST}
+    printf "Remove admin privileges from previous CES admin group %s...\\n" ${CES_ADMIN_GROUP_LAST}
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
 
     remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "admin" "${DOGU_ADMIN}" "${dogu_admin_password}"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -29,6 +29,7 @@ MAIL_ADDRESS=$(doguctl config --default "sonar@${DOMAIN}" --global mail_address)
 QUALITY_PROFILE_DIR="/var/lib/qualityprofiles"
 CURL_LOG_LEVEL="--silent"
 HEALTH_TIMEOUT=600
+PERMISSIONS="admin profileadmin gateadmin provisioning"
 
 function import_quality_profiles_if_present {
   AUTH_USER=$1
@@ -153,10 +154,12 @@ function set_updatecenter_url_if_configured_in_registry() {
 function grant_admin_group_permissions() {
     local admin_group=$1
     printf "\\nAdding admin privileges to CES admin group...\\n"
-    grant_permission_to_group_via_rest_api "${admin_group}" "admin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-    grant_permission_to_group_via_rest_api "${admin_group}" "profileadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-    grant_permission_to_group_via_rest_api "${admin_group}" "gateadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-    grant_permission_to_group_via_rest_api "${admin_group}" "provisioning" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+
+    for permission in $PERMISSIONS
+    do
+      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
+      grant_permission_to_group_via_rest_api "${admin_group}" "$permission" "${DOGU_ADMIN}" "${dogu_admin_password}"
+    done
 }
 
 function run_first_start_tasks() {
@@ -238,10 +241,11 @@ function remove_permissions_from_last_admin_group() {
     printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${CES_ADMIN_GROUP_LAST}
     local dogu_admin_password=$(doguctl config -e dogu_admin_password)
 
-    remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "admin" "${DOGU_ADMIN}" "${dogu_admin_password}"
-    remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "profileadmin" "${DOGU_ADMIN}" "${dogu_admin_password}"
-    remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "gateadmin" "${DOGU_ADMIN}" "${dogu_admin_password}"
-    remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "provisioning" "${DOGU_ADMIN}" "${dogu_admin_password}"
+    for permission in $PERMISSIONS
+    do
+      printf "remove permission '%s' from group '%s'...\\n" ${permission} ${CES_ADMIN_GROUP_LAST}
+      remove_permission_of_group_via_rest_api "${CES_ADMIN_GROUP_LAST}" "$permission" "${DOGU_ADMIN}" "${dogu_admin_password}"
+    done
 }
 
 # returns value 1 if both admin group names have the same value. Otherwise, it returns 0

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -150,15 +150,20 @@ function set_updatecenter_url_if_configured_in_registry() {
   fi
 }
 
+function grant_admin_group_permissions() {
+    local admin_group=$1
+    printf "\\nAdding admin privileges to CES admin group...\\n"
+    grant_permission_to_group_via_rest_api "${admin_group}" "admin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+    grant_permission_to_group_via_rest_api "${admin_group}" "profileadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+    grant_permission_to_group_via_rest_api "${admin_group}" "gateadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+    grant_permission_to_group_via_rest_api "${admin_group}" "provisioning" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+}
+
 function run_first_start_tasks() {
   echo  "Adding CES admin group..."
   create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
-  printf "\\nAdding admin privileges to CES admin group...\\n"
-  grant_permission_to_group_via_rest_api "${CES_ADMIN_GROUP}" "admin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-  grant_permission_to_group_via_rest_api "${CES_ADMIN_GROUP}" "profileadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-  grant_permission_to_group_via_rest_api "${CES_ADMIN_GROUP}" "gateadmin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
-  grant_permission_to_group_via_rest_api "${CES_ADMIN_GROUP}" "provisioning" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+  grant_admin_group_permissions ${CES_ADMIN_GROUP}
 
   set_updatecenter_url_if_configured_in_registry "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
@@ -225,8 +230,7 @@ function subsequentSonarStart() {
     echo  "Adding CES admin group..."
     create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
-    printf "\\nAdding admin privileges to CES admin group...\\n"
-    grant_permission_to_group_via_rest_api "${CES_ADMIN_GROUP}" "admin" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
+    grant_admin_group_permissions ${CES_ADMIN_GROUP}
   fi
 }
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -155,11 +155,12 @@ function set_updatecenter_url_if_configured_in_registry() {
 
 function grant_admin_group_permissions() {
     local admin_group=$1
-    local dogu_admin_password=$(doguctl config -e dogu_admin_password)
+    local dogu_admin_password
+    dogu_admin_password=$(doguctl config -e dogu_admin_password)
     printf "Adding admin privileges to CES admin group...\\n"
     for permission in ${ADMIN_PERMISSIONS}
     do
-      printf "grant permission '%s' to group '%s'...\\n" ${permission} ${admin_group}
+      printf "grant permission '%s' to group '%s'...\\n" "${permission}" "${admin_group}"
       grant_permission_to_group_via_rest_api "${admin_group}" "${permission}" "${DOGU_ADMIN}" "${dogu_admin_password}"
     done
 }
@@ -168,7 +169,7 @@ function run_first_start_tasks() {
   echo  "Adding CES admin group '${CES_ADMIN_GROUP}'..."
   create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
-  grant_admin_group_permissions ${CES_ADMIN_GROUP}
+  grant_admin_group_permissions "${CES_ADMIN_GROUP}"
 
   set_updatecenter_url_if_configured_in_registry "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
@@ -235,17 +236,19 @@ function subsequentSonarStart() {
     echo  "Adding CES admin group '${CES_ADMIN_GROUP}'..."
     create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"
 
-    grant_admin_group_permissions ${CES_ADMIN_GROUP}
+    grant_admin_group_permissions "${CES_ADMIN_GROUP}"
   fi
 }
 
 function remove_permissions_from_last_admin_group() {
     local admin_group=${CES_ADMIN_GROUP_LAST}
-    printf "Remove admin privileges from previous CES admin group '%s'...\\n" ${admin_group}
-    local dogu_admin_password=$(doguctl config -e dogu_admin_password)
+    printf "Remove admin privileges from previous CES admin group '%s'...\\n" "${admin_group}"
+    local dogu_admin_password
+    dogu_admin_password=$(doguctl config -e dogu_admin_password)
+
     for permission in ${ADMIN_PERMISSIONS}
     do
-      printf "remove permission '%s' from group '%s'...\\n" ${permission} ${admin_group}
+      printf "remove permission '%s' from group '%s'...\\n" "${permission}" "${admin_group}"
       remove_permission_of_group_via_rest_api "${admin_group}" "${permission}" "${DOGU_ADMIN}" "${dogu_admin_password}"
     done
 }
@@ -318,7 +321,7 @@ else
     echo "Did not detect a change of the admin group. Continue as usual..."
 fi
 
-update_last_admin_group_in_registry ${CES_ADMIN_GROUP}
+update_last_admin_group_in_registry "${CES_ADMIN_GROUP}"
 
 echo "Setting sonar.core.serverBaseURL..."
 set_property_via_rest_api "sonar.core.serverBaseURL" "https://${FQDN}/sonar" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -255,7 +255,12 @@ function remove_permissions_from_last_admin_group() {
 
 # It returns 0 if the admin group names differs from each other. Otherwise, it returns the value 1.
 function has_admin_group_changed() {
-    return $(expr "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST")
+    if [[ "$CES_ADMIN_GROUP" = "$CES_ADMIN_GROUP_LAST" ]];
+    then
+        return 1
+    else
+        return 0
+    fi
 }
 
 ### End of function declarations, work is done now

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -302,6 +302,7 @@ then
 else
     remove_permissions_from_last_admin_group
 fi
+update_last_admin_group_in_registry ${CES_ADMIN_GROUP}
 
 echo "Setting sonar.core.serverBaseURL..."
 set_property_via_rest_api "sonar.core.serverBaseURL" "https://${FQDN}/sonar" "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}"

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -159,11 +159,11 @@ function getLastAdminGroupOrGlobalAdminGroup() {
 
     if admin_group_last=$(doguctl config admin_group_last) ;
     then
-        printf ${admin_group_last}
+        printf "%s" "${admin_group_last}"
     else
         # this group name is used either way to check if it is equal with the global admin group
         # instead of unnecessarily check for empty strings we return a valid value for the equal-check
-        printf $(doguctl config --global admin_group)
+        printf "%s" "$(doguctl config --global admin_group)"
     fi
 }
 
@@ -171,5 +171,5 @@ function update_last_admin_group_in_registry() {
     echo "Update SonarQube admin group in registry..."
 
     local newAdminGroup=$1
-    doguctl config admin_group_last ${newAdminGroup}
+    doguctl config admin_group_last "${newAdminGroup}"
 }

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -143,3 +143,26 @@ function set_successful_first_start_flag() {
   echo "Setting successfulFirstStart registry key..."
   doguctl config successfulFirstStart true
 }
+
+
+# getLastAdminGroupOrGlobalAdminGroup echoes admin_group__last value from the registry if it was set, otherwise
+# it echoes the current (global) admin_group.
+#
+# Store the result in a variable like this:
+#  myAdminGroup=$(getLastAdminGroupOrGlobalAdminGroup)
+#
+# note that 'echo' returns the string to the caller and _does not_ print the value to stdout. It is also not possible
+# to add debug echo's/printf's/etc.
+# see https://stackoverflow.com/questions/14482943/
+function getLastAdminGroupOrGlobalAdminGroup() {
+    local admin_group_last=""
+
+    if admin_group_last=$(doguctl config admin_group_last) ;
+    then
+        printf ${admin_group_last}
+    else
+        # this group name is used either way to check if it is equal with the global admin group
+        # instead of unnecessarily check for empty strings we return a valid value for the equal-check
+        printf $(doguctl config --global admin_group)
+    fi
+}

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -166,3 +166,10 @@ function getLastAdminGroupOrGlobalAdminGroup() {
         printf $(doguctl config --global admin_group)
     fi
 }
+
+function update_last_admin_group_in_registry() {
+    echo "Update SonarQube admin group in registry..."
+
+    local newAdminGroup=$1
+    doguctl config admin_group_last ${newAdminGroup}
+}


### PR DESCRIPTION
This PR solves issue #30 in which changing the global admin group name leads to an unusable SonarQube because the new group misses some vital permissions as well as leaving the old admin group fully functional.

This PR removes the permissions from the (by-then) previous admin group.

co-authored with @pistengeier 