### PR TITLE
Bugfix/46 quality profiles disappear on first installation

### DIFF
--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -276,8 +276,18 @@ function subsequent_sonar_start() {
 
   set_updatecenter_url_if_configured_in_registry "${TEMPORARY_ADMIN_USER}" "${TEMPORARY_ADMIN_PASSWORD}"
 
-  # Creating CES admin group if not existent or if it has changed
+  resetCesAdmin "${TEMPORARY_ADMIN_USER}" "${TEMPORARY_ADMIN_PASSWORD}"
+}
+
+function resetCesAdmin() {
+  echo "Ensure that CES admin exists and has sufficient privileges..."
+
+  local TEMPORARY_ADMIN_USER="${1}"
+  local TEMPORARY_ADMIN_PASSWORD="${2}"
+
+  # Create CES admin group if not existent or if it has changed
   GROUP_NAME=$(curl ${CURL_LOG_LEVEL} --fail -u "${TEMPORARY_ADMIN_USER}":"${TEMPORARY_ADMIN_PASSWORD}" -X GET "http://localhost:9000/sonar/api/user_groups/search" | jq ".groups[] | select(.name==\"${CES_ADMIN_GROUP}\")" | jq '.name')
+
   if [[ -z "${GROUP_NAME}" ]]; then
     echo "Adding CES admin group '${CES_ADMIN_GROUP}'..."
     create_user_group_via_rest_api "${CES_ADMIN_GROUP}" "CESAdministratorGroup" "${TEMPORARY_ADMIN_USER}" "${TEMPORARY_ADMIN_PASSWORD}"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -87,7 +87,7 @@ function importQualityProfiles() {
 
       if [[ "${importFailures}" != "0" ]]; then
         echo "ERROR: There were quality profiles import failures from file ${file}. Import returned: '${importResponse}'"
-        # do not remove file so the customer has the chance to  the file content
+        # do not remove file so the user has the chance to examine the file content
         continue
       fi
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -288,17 +288,22 @@ function has_admin_group_changed() {
 }
 
 function install_default_plugins() {
+  echo "Installing preconfigured plugins..."
+  local PLUGINS
+
   if PLUGINS=$(doguctl config sonar.plugins.default); then
-    USER=${1}
-    PASSWORD=${2}
-
     echo "found plugins '${PLUGINS}' to be installed on startup"
+    local USER=${1}
+    local PASSWORD=${2}
 
+    local storedIFS="${IFS}"
     IFS=','
+
     for plugin in $PLUGINS; do
       install_plugin_via_api "$plugin" "$USER" "$PASSWORD"
     done
 
+    IFS="${storedIFS}"
     echo "finished installation of default plugins"
   else
     echo "no key sonar.plugins.default found"

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -46,15 +46,15 @@ TEMPORARY_ADMIN_GROUP=$(doguctl random)
 TEMPORARY_ADMIN_USER=$(doguctl random)
 TEMPORARY_ADMIN_PASSWORD=$(doguctl random)
 
-function areQualityProfilesPresent() {
+function areQualityProfilesPresentToImport() {
   echo "Check for quality profiles to import..."
 
   local resultCode
   if [[ "$(ls -A ${QUALITY_PROFILE_DIR})" ]]; then
-    echo "Quality profiles are present..."
+    echo "Quality profiles are present for import..."
     resultCode=0
   else
-    echo "There are no quality profiles..."
+    echo "There are no quality profiles for import present..."
     resultCode=1
   fi
 
@@ -467,9 +467,8 @@ fi
 echo "Removing temporary admin..."
 remove_temporary_admin_user_and_group
 
-# Please note!
 # in order to import quality profiles the plugin installation must be finished along with a sonar restart
-if areQualityProfilesPresent; then
+if areQualityProfilesPresentToImport; then
   # the temporary admin has different permissions during first start and subsequent start
   # only the subsequent temporary admin has sufficient privileges to import quality profiles
   create_temporary_admin_for_subsequent_start

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -3,6 +3,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+echo "                                     ./////,                    "
+echo "                                 ./////==//////*                "
+echo "                                ////.  ___   ////.              "
+echo "                         ,**,. ////  ,////A,  */// ,**,.        "
+echo "                    ,/////////////*  */////*  *////////////A    "
+echo "                   ////'        \VA.   '|'   .///'       '///*  "
+echo "                  *///  .*///*,         |         .*//*,   ///* "
+echo "                  (///  (//////)**--_./////_----*//////)   ///) "
+echo "                   V///   '°°°°      (/////)      °°°°'   ////  "
+echo "                    V/////(////////\. '°°°' ./////////(///(/'   "
+echo "                       'V/(/////////////////////////////V'      "
+
 # import util functions:
 # execute_sql_statement_on_database()
 # wait_for_sonar_status_endpoint()


### PR DESCRIPTION
This PR resolves #46 by changing the order of plugin installation, SonarQube-Restart and quality profile import.

Since there is a non-trivial dependency from quality profiles to installed plugins this PR solves the matter by adding another SonarQube restart. This restart takes only place when there are actually quality profiles to be imported. Otherwise the restart is skipped in order to shave off unnecessary downtime.