### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to configure the memory limits with `cesapp edit-config`
-- Optimized max heap size in limited dockerized environments (#51)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the sonar main/web/search/compute processes inside the container via `cesapp edit-conf` (#51)
 
 ## [v7.9.4-1] - 2020-11-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to configure the memory limits with `cesapp edit-config`
+- Optimized max heap size in limited dockerized environments (#51)
+
 ## [v7.9.4-1] - 2020-11-13
 ### Changed
 - Upgrade to SonarQube 7.9.4 LTS; #49

--- a/dogu.json
+++ b/dogu.json
@@ -57,6 +57,22 @@
       "Name": "sonar.plugins.default",
       "Description": "Comma separated list of plugin names to install on start",
       "Optional": true
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1g of memory for sonar.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description": "Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "HealthChecks": [

--- a/dogu.json
+++ b/dogu.json
@@ -60,7 +60,7 @@
     },
     {
       "Name": "container_config/memory_limit",
-      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1g of memory for sonar.",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
@@ -72,6 +72,51 @@
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/java_sonar_main_max_ram_percentage",
+      "Description":"Limits the heap stack size of the Sonar main process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar maim: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_sonar_main_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Sonar main process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar main: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_sonar_web_max_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Sonar web background process to the configured percentage of the available physical memory. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar web: 10%",
+      "Optional": true,
+      "Default": "10.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_sonar_search_max_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Sonar search background process to the configured percentage of the available physical memory. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar search: 10%",
+      "Optional": true,
+      "Default": "10.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_sonar_cengine_max_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Sonar compute engine background process to the configured percentage of the available physical memory. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar compute engine: 10%",
+      "Optional": true,
+      "Default": "10.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
       }
     }
   ],

--- a/dogu.json
+++ b/dogu.json
@@ -76,7 +76,7 @@
     },
     {
       "Name": "container_config/java_sonar_main_max_ram_percentage",
-      "Description":"Limits the heap stack size of the Sonar main process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar maim: 25%",
+      "Description":"Limits the heap stack size of the Sonar main process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Sonar main: 25%",
       "Optional": true,
       "Default": "25.0",
       "Validation": {

--- a/resources/opt/sonar/conf/sonar.properties.tpl
+++ b/resources/opt/sonar/conf/sonar.properties.tpl
@@ -403,7 +403,29 @@ sonar.log.console=true
 
 # java opts
 # Always set javax.net.ssl.trustStore to SONARQUBE_HOME/truststore.jks
-sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/opt/sonar/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Djdk.http.auth.tunneling.disabledSchemes=""
+sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom \
+                             -Djava.awt.headless=true \
+                             -Djava.net.preferIPv4Stack=true \
+                             -Djavax.net.ssl.trustStore=/opt/sonar/truststore.jks \
+                             -Djavax.net.ssl.trustStorePassword=changeit \
+                             -Djdk.http.auth.tunneling.disabledSchemes=""
+
+{{ if .Config.Exists "container_config/memory_limit" }}
+# Use javaOpts to override -Xmx options for sonar web
+sonar.web.javaOpts=-XX:MaxRAMPercentage=15.0 \
+                   -XX:MinRAMPercentage=15.0 \
+                   -XX:InitialRAMPercentage=15.0
+
+# Use javaOpts to override -Xmx options for sonar search
+sonar.search.javaOpts=-XX:MaxRAMPercentage=15.0 \
+                      -XX:MinRAMPercentage=15.0 \
+                      -XX:InitialRAMPercentage=15.0
+
+# Use javaOpts to override -Xmx options for sonar compute engine
+sonar.ce.javaOpts=-XX:MaxRAMPercentage=15.0 \
+                  -XX:MinRAMPercentage=15.0 \
+                  -XX:InitialRAMPercentage=15.0
+{{ end }}
 
 {{ if .Config.Exists "sonar.updatecenter.url" }}
 sonar.updatecenter.url = {{ .Config.Get "sonar.updatecenter.url" }}

--- a/resources/opt/sonar/conf/sonar.properties.tpl
+++ b/resources/opt/sonar/conf/sonar.properties.tpl
@@ -412,19 +412,19 @@ sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom \
 
 {{ if .Config.Exists "container_config/memory_limit" }}
 # Use javaOpts to override -Xmx options for sonar web
-sonar.web.javaOpts=-XX:MaxRAMPercentage=java_sonar_web_max_min_ram_percentage \
-                   -XX:MinRAMPercentage=java_sonar_web_max_min_ram_percentage \
-                   -XX:InitialRAMPercentage=java_sonar_web_max_min_ram_percentage
+sonar.web.javaOpts=-XX:MaxRAMPercentage={{ .Config.Get "container_config/java_sonar_web_max_min_ram_percentage"}} \
+                   -XX:MinRAMPercentage={{ .Config.Get "container_config/java_sonar_web_max_min_ram_percentage"}} \
+                   -XX:InitialRAMPercentage={{ .Config.Get "container_config/java_sonar_web_max_min_ram_percentage"}}
 
 # Use javaOpts to override -Xmx options for sonar search
-sonar.search.javaOpts=-XX:MaxRAMPercentage=java_sonar_search_max_min_ram_percentage  \
-                      -XX:MinRAMPercentage=java_sonar_search_max_min_ram_percentage \
-                      -XX:InitialRAMPercentage=java_sonar_search_max_min_ram_percentage
+sonar.search.javaOpts=-XX:MaxRAMPercentage={{ .Config.Get "container_config/java_sonar_search_max_min_ram_percentage"}}  \
+                      -XX:MinRAMPercentage={{ .Config.Get "container_config/java_sonar_search_max_min_ram_percentage"}} \
+                      -XX:InitialRAMPercentage={{ .Config.Get "container_config/java_sonar_search_max_min_ram_percentage"}}
 
 # Use javaOpts to override -Xmx options for sonar compute engine
-sonar.ce.javaOpts=-XX:MaxRAMPercentage=java_sonar_cengine_max_min_ram_percentage \
-                  -XX:MinRAMPercentage=java_sonar_cengine_max_min_ram_percentage \
-                  -XX:InitialRAMPercentage=java_sonar_cengine_max_min_ram_percentage
+sonar.ce.javaOpts=-XX:MaxRAMPercentage={{ .Config.Get "container_config/java_sonar_cengine_max_min_ram_percentage"}} \
+                  -XX:MinRAMPercentage={{ .Config.Get "container_config/java_sonar_cengine_max_min_ram_percentage"}} \
+                  -XX:InitialRAMPercentage={{ .Config.Get "container_config/java_sonar_cengine_max_min_ram_percentage"}}
 {{ end }}
 
 {{ if .Config.Exists "sonar.updatecenter.url" }}

--- a/resources/opt/sonar/conf/sonar.properties.tpl
+++ b/resources/opt/sonar/conf/sonar.properties.tpl
@@ -412,19 +412,19 @@ sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom \
 
 {{ if .Config.Exists "container_config/memory_limit" }}
 # Use javaOpts to override -Xmx options for sonar web
-sonar.web.javaOpts=-XX:MaxRAMPercentage=15.0 \
-                   -XX:MinRAMPercentage=15.0 \
-                   -XX:InitialRAMPercentage=15.0
+sonar.web.javaOpts=-XX:MaxRAMPercentage=java_sonar_web_max_min_ram_percentage \
+                   -XX:MinRAMPercentage=java_sonar_web_max_min_ram_percentage \
+                   -XX:InitialRAMPercentage=java_sonar_web_max_min_ram_percentage
 
 # Use javaOpts to override -Xmx options for sonar search
-sonar.search.javaOpts=-XX:MaxRAMPercentage=15.0 \
-                      -XX:MinRAMPercentage=15.0 \
-                      -XX:InitialRAMPercentage=15.0
+sonar.search.javaOpts=-XX:MaxRAMPercentage=java_sonar_search_max_min_ram_percentage  \
+                      -XX:MinRAMPercentage=java_sonar_search_max_min_ram_percentage \
+                      -XX:InitialRAMPercentage=java_sonar_search_max_min_ram_percentage
 
 # Use javaOpts to override -Xmx options for sonar compute engine
-sonar.ce.javaOpts=-XX:MaxRAMPercentage=15.0 \
-                  -XX:MinRAMPercentage=15.0 \
-                  -XX:InitialRAMPercentage=15.0
+sonar.ce.javaOpts=-XX:MaxRAMPercentage=java_sonar_cengine_max_min_ram_percentage \
+                  -XX:MinRAMPercentage=java_sonar_cengine_max_min_ram_percentage \
+                  -XX:InitialRAMPercentage=java_sonar_cengine_max_min_ram_percentage
 {{ end }}
 
 {{ if .Config.Exists "sonar.updatecenter.url" }}

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -142,24 +142,6 @@ function writeProxyAuthenticationCredentialsTo(){
 }
 
 function render_properties_template() {
-  # Sed memory limits for subprocesses. Has an advantage against storing them in the template file
-  # as the default values only needs to be maintained in the dogu.json
-  if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ]];  then
-
-    # Retrieve configurable java limits from etcd, valid default values exist
-    WEB_MINMAX=$(doguctl config "container_config/java_sonar_web_max_min_ram_percentage")
-    echo "Setting memory limits for sonar web process to MaxRAMPercentage: ${WEB_MINMAX} and MinRAMPercentage: ${WEB_MINMAX}..."
-    sed -i "s/java_sonar_web_max_min_ram_percentage/${WEB_MINMAX}/"  "${SONAR_PROPERTIES_FILE}.tpl"
-
-    SEARCH_MINMAX=$(doguctl config "container_config/java_sonar_search_max_min_ram_percentage")
-    echo "Setting memory limits for sonar search process to MaxRAMPercentage: ${SEARCH_MINMAX} and MinRAMPercentage: ${SEARCH_MINMAX}..."
-    sed -i "s/java_sonar_search_max_min_ram_percentage/${SEARCH_MINMAX}/"  "${SONAR_PROPERTIES_FILE}.tpl"
-
-    CENGINE_MINMAX=$(doguctl config "container_config/java_sonar_cengine_max_min_ram_percentage")
-    echo "Setting memory limits for sonar compute engine process to MaxRAMPercentage: ${CENGINE_MINMAX} and MinRAMPercentage: ${CENGINE_MINMAX}..."
-    sed -i "s/java_sonar_cengine_max_min_ram_percentage/${CENGINE_MINMAX}/"  "${SONAR_PROPERTIES_FILE}.tpl"
-  fi
-
   doguctl template "${SONAR_PROPERTIES_FILE}.tpl" "${SONAR_PROPERTIES_FILE}"
 }
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -232,9 +232,18 @@ function run_first_start_tasks() {
 function startSonarQubeInBackground() {
   local reason="${1}"
 
-  echo "Starting SonarQube for ${reason}... "
-  java -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar &
-  SONAR_PROCESS_ID=$!
+  if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" ]];  then
+    echo "Starting SonarQube without memory limits for ${reason}... "
+    java -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar \
+       & SONAR_PROCESS_ID=$!
+  else
+    echo "Starting SonarQube with memory limits for ${reason}... "
+    java -XX:MaxRAMPercentage=40.0 \
+         -XX:MinRAMPercentage=40.0 \
+                  -XX:+PrintFlagsFinal \
+         -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar \
+         & SONAR_PROCESS_ID=$!
+  fi
 
   wait_for_sonar_status_endpoint "${HEALTH_TIMEOUT}"
 
@@ -486,5 +495,13 @@ ensure_correct_branch_plugin_state
 doguctl state "ready"
 
 exec tail -F /opt/sonar/logs/es.log & # this tail on the elasticsearch logs is a temporary workaround, see https://github.com/docker-library/official-images/pull/6361#issuecomment-516184762
-echo "Starting SonarQube..."
-exec java -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar
+
+if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" ]];  then
+  echo "Starting SonarQube without memory limits..."
+  exec java -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar
+else
+  echo "Starting SonarQube with memory limits..."
+  exec java -XX:MaxRAMPercentage=40.0 \
+            -XX:MinRAMPercentage=40.0 \
+            -jar /opt/sonar/lib/sonar-application-"${SONAR_VERSION}".jar
+fi


### PR DESCRIPTION
Fixes #51.

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the Sonar-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0