### PR TITLE
Bugfix/63 fix cas identity provider by db migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix CAS authentication error with previously logged-in users after migration (#63)
 
 ## [v8.9.0-2] - 2021-06-16
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix CAS authentication error with previously logged-in users after migration (#63)
+- Fix CAS authentication error with previously logged-in users during migration (#63)
 
 ## [v8.9.0-2] - 2021-06-16
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ unit-test-shell-local: $(BASH_SRC) $(PASSWD) $(ETCGROUP) $(HOME_DIR) buildTestIm
 	@docker run --rm \
 		-u "$(UID_NR):$(GID_NR)" \
 		-v $(PASSWD):/etc/passwd:ro \
-		-v $(ETCGROUP):/etc/group:ro \
 		-v $(HOME_DIR):/home/$(USER) \
 		-v $(WORKDIR):$(WORKSPACE) \
 		-w $(WORKSPACE) \

--- a/docs/development/developing_de.md
+++ b/docs/development/developing_de.md
@@ -21,13 +21,15 @@ Es gibt zwei Alternativen zum Testen von Entwicklungsversionen des [Sonar CAS Pl
    - eine neue Zeile für `COPY` für das Plugin hinzufügen, etwa so:
       - `COPY --chown=1000:1000 sonar-cas-plugin-3.0.0-SNAPSHOT.jar ${SONARQUBE_HOME}/sonar-cas-plugin-3.0.0-SNAPSHOT.jar`
 
-## Shell-Tests
+## Shell-Tests mit BATS
 
 Bash-Tests können im Verzeichnis `unitTests` erstellt und geändert werden. Das make-Target `unit-test-shell` unterstützt hierbei mit einer verallgemeinerten Bash-Testumgebung.
 
 ```bash
 make unit-test-shell
 ```
+
+BATS wurde so konfiguriert, dass es JUnit kompatible Testreports in `target/shell_test_reports/` hinterlässt.
 
 Um testbare Shell-Skripte zu schreiben, sollten diese Aspekte beachtet werden:
 

--- a/docs/development/developing_en.md
+++ b/docs/development/developing_en.md
@@ -21,13 +21,15 @@ There are two alternatives for testing development versions of the [Sonar CAS Pl
     - add a new line for `COPY`ing your plugin, like so:
         - `COPY --chown=1000:1000 sonar-cas-plugin-3.0.0-SNAPSHOT.jar ${SONARQUBE_HOME}/sonar-cas-plugin-3.0.0-SNAPSHOT.jar`
 
-## Shell testing
+## Shell testing with BATS
 
 You can create and amend bash tests in the `unitTests` directory. The make target `unit-test-shell` will support you with a generalized bash test environment.
 
 ```bash
 make unit-test-shell
 ```
+
+BATS is configured to leave JUnit compatible reports in `target/shell_test_reports/`.
 
 In order to write testable shell scripts these aspects should be respected:
 

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -19,7 +19,7 @@ function reinstall_plugins() {
   while IFS=',' read -ra ADDR; do
     for PLUGIN in "${ADDR[@]}"; do
       echo "Checking if plugin ${PLUGIN} is installed already..."
-      INSTALLED_PLUGINS=$(curl ${CURL_LOG_LEVEL} --fail -u "${1}":"${2}" -X GET localhost:9000/sonar/api/plugins/installed | jq '.plugins' | jq '.[]' | jq -r '.key')
+      INSTALLED_PLUGINS=$(curl "${CURL_LOG_LEVEL}" --fail -u "${1}":"${2}" -X GET localhost:9000/sonar/api/plugins/installed | jq '.plugins' | jq '.[]' | jq -r '.key')
       if [[ ${INSTALLED_PLUGINS} == *"${PLUGIN}"* ]]; then
         echo "Plugin ${PLUGIN} is installed already"
       else
@@ -44,7 +44,6 @@ function migrate_cas_identity_provider_in_db() {
 function run_post_upgrade() {
   FROM_VERSION="${1}"
   TO_VERSION="${2}"
-  FROM_MAJOR_VERSION=$(echo "${FROM_VERSION}" | cut -d '.' -f1)
   TO_MAJOR_VERSION=$(echo "${TO_VERSION}" | cut -d '.' -f1)
   WAIT_TIMEOUT=600
   CURL_LOG_LEVEL="--silent"

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -126,7 +126,7 @@ function run_post_upgrade() {
     curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=provisioning&groupName=${CES_ADMIN_GROUP}"
   fi
 
-  if [[ "${TO_MAJOR_VERSION}" -ge 8 ]] && [[ "${FROM_MAJOR_VERSION}" -lt 8 ]]; then
+  if [[ "${TO_MAJOR_VERSION}" -eq 8 ]]; then
     migrate_cas_identity_provider_in_db
   fi
 

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -44,82 +44,98 @@ function reinstall_plugins() {
   fi
 }
 
-######
+function migrate_cas_identity_provider_in_db() {
+  echo "Migrating DB: Update accounts associated with identity provider CAS to SonarQube..."
+  execute_sql_statement_on_database "update users set external_identity_provider='sonarqube' where external_identity_provider='cas';"
+}
 
-echo "Running post-upgrade script..."
+function run_post_upgrade() {
+  echo "Running post-upgrade script..."
 
-# Migrate saved extensions folder to its own volume
-if [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
-  mkdir -p /opt/sonar/extensions
-  cp -R /opt/sonar/data/extensions/* /opt/sonar/extensions/
-  rm -rf /opt/sonar/data/extensions
-fi
-
-echo "Waiting for SonarQube status endpoint to be available (max. ${WAIT_TIMEOUT} seconds)..."
-wait_for_sonar_status_endpoint ${WAIT_TIMEOUT}
-
-echo "Checking if db migration is needed..."
-DB_MIGRATION_STATUS=$(curl "${CURL_LOG_LEVEL}" --fail -X GET http://localhost:9000/sonar/api/system/db_migration_status | jq -r '.state')
-if [[ "${DB_MIGRATION_STATUS}" = "MIGRATION_REQUIRED" ]]; then
-  echo "Database migration is required. Migrating database now..."
-  curl "${CURL_LOG_LEVEL}" --fail -X POST http://localhost:9000/sonar/api/system/migrate_db
-  printf "\\nWaiting for db migration to succeed (max. %s seconds)...\\n" ${WAIT_TIMEOUT}
-  for i in $(seq 1 "${WAIT_TIMEOUT}"); do
-    DB_MIGRATION_STATE=$(curl "${CURL_LOG_LEVEL}" --fail -X GET http://localhost:9000/sonar/api/system/db_migration_status | jq -r '.state')
-    if [[ "${DB_MIGRATION_STATE}" = "MIGRATION_SUCCEEDED" ]]; then
-      echo "Database migration has been successful: ${DB_MIGRATION_STATE}"
-      break
-    fi
-    if [[ "$i" -eq ${WAIT_TIMEOUT} ]] ; then
-      echo "Database migration did not succeed within ${WAIT_TIMEOUT} seconds; status is ${DB_MIGRATION_STATE}."
-      exit 1
-    fi
-    # waiting for db migration
-    sleep 1
-  done
-else
-  echo "No db migration is needed"
-fi
-
-if [[ ${FROM_VERSION} == "6"* ]] && [[ ${TO_VERSION} == "7.9"* ]]; then
-  TEMPORARY_ADMIN_USER=$(doguctl random)
-  PW=$(doguctl random)
-  SALT=$(doguctl random)
-  HASH=$(getSHA1PW "${PW}" "${SALT}")
-  add_temporary_admin_user "${TEMPORARY_ADMIN_USER}" "${HASH}" "${SALT}"
-  # reinstall missing plugins if there are any
-  if doguctl config install_plugins > /dev/null; then
-
-    echo "Waiting for SonarQube to get up (max ${WAIT_TIMEOUT} seconds)..."
-    wait_for_sonar_to_get_up ${WAIT_TIMEOUT}
-
-    echo "Waiting for SonarQube to get healthy (max. ${WAIT_TIMEOUT} seconds)..."
-    # default admin credentials (admin, admin) are used
-    wait_for_sonar_to_get_healthy ${WAIT_TIMEOUT} "${TEMPORARY_ADMIN_USER}" "${PW}" ${CURL_LOG_LEVEL}
-
-    reinstall_plugins "${TEMPORARY_ADMIN_USER}" "${PW}"
-
-    doguctl config --remove install_plugins
+  # Migrate saved extensions folder to its own volume
+  if [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
+    mkdir -p /opt/sonar/extensions
+    cp -R /opt/sonar/data/extensions/* /opt/sonar/extensions/
+    rm -rf /opt/sonar/data/extensions
   fi
 
-  remove_temporary_admin_user "${TEMPORARY_ADMIN_USER}"
-fi
+  echo "Waiting for SonarQube status endpoint to be available (max. ${WAIT_TIMEOUT} seconds)..."
+  wait_for_sonar_status_endpoint ${WAIT_TIMEOUT}
 
-if [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
-  # grant further permissions to CES admin group via API
-  # TODO: Extract grant_permission_to_group_via_rest_api function from startup.sh into util.sh and use it instead
-  CES_ADMIN_GROUP=$(doguctl config --global admin_group)
-  DOGU_ADMIN_PASSWORD=$(doguctl config -e dogu_admin_password)
-  echo "Waiting for SonarQube to get up (max. ${WAIT_TIMEOUT} seconds)..."
-  wait_for_sonar_to_get_up "${WAIT_TIMEOUT}"
-  echo "Waiting for SonarQube to get healthy (max. ${WAIT_TIMEOUT} seconds)..."
-  wait_for_sonar_to_get_healthy ${WAIT_TIMEOUT} "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}" ${CURL_LOG_LEVEL}
-  # grant profileadmin permission
-  curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=profileadmin&groupName=${CES_ADMIN_GROUP}"
-  # grant gateadmin permission
-  curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=gateadmin&groupName=${CES_ADMIN_GROUP}"
-  # grant provisioning permission
-  curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=provisioning&groupName=${CES_ADMIN_GROUP}"
-fi
+  echo "Checking if db migration is needed..."
+  DB_MIGRATION_STATUS=$(curl "${CURL_LOG_LEVEL}" --fail -X GET http://localhost:9000/sonar/api/system/db_migration_status | jq -r '.state')
+  if [[ "${DB_MIGRATION_STATUS}" = "MIGRATION_REQUIRED" ]]; then
+    echo "Database migration is required. Migrating database now..."
+    curl "${CURL_LOG_LEVEL}" --fail -X POST http://localhost:9000/sonar/api/system/migrate_db
+    printf "\\nWaiting for db migration to succeed (max. %s seconds)...\\n" ${WAIT_TIMEOUT}
+    for i in $(seq 1 "${WAIT_TIMEOUT}"); do
+      DB_MIGRATION_STATE=$(curl "${CURL_LOG_LEVEL}" --fail -X GET http://localhost:9000/sonar/api/system/db_migration_status | jq -r '.state')
+      if [[ "${DB_MIGRATION_STATE}" = "MIGRATION_SUCCEEDED" ]]; then
+        echo "Database migration has been successful: ${DB_MIGRATION_STATE}"
+        break
+      fi
+      if [[ "$i" -eq ${WAIT_TIMEOUT} ]] ; then
+        echo "Database migration did not succeed within ${WAIT_TIMEOUT} seconds; status is ${DB_MIGRATION_STATE}."
+        exit 1
+      fi
+      # waiting for db migration
+      sleep 1
+    done
+  else
+    echo "No db migration is needed"
+  fi
 
-doguctl config post_upgrade_running false
+  if [[ ${FROM_VERSION} == "6"* ]] && [[ ${TO_VERSION} == "7.9"* ]]; then
+    TEMPORARY_ADMIN_USER=$(doguctl random)
+    PW=$(doguctl random)
+    SALT=$(doguctl random)
+    HASH=$(getSHA1PW "${PW}" "${SALT}")
+    add_temporary_admin_user "${TEMPORARY_ADMIN_USER}" "${HASH}" "${SALT}"
+    # reinstall missing plugins if there are any
+    if doguctl config install_plugins > /dev/null; then
+
+      echo "Waiting for SonarQube to get up (max ${WAIT_TIMEOUT} seconds)..."
+      wait_for_sonar_to_get_up ${WAIT_TIMEOUT}
+
+      echo "Waiting for SonarQube to get healthy (max. ${WAIT_TIMEOUT} seconds)..."
+      # default admin credentials (admin, admin) are used
+      wait_for_sonar_to_get_healthy ${WAIT_TIMEOUT} "${TEMPORARY_ADMIN_USER}" "${PW}" ${CURL_LOG_LEVEL}
+
+      reinstall_plugins "${TEMPORARY_ADMIN_USER}" "${PW}"
+
+      doguctl config --remove install_plugins
+    fi
+
+    remove_temporary_admin_user "${TEMPORARY_ADMIN_USER}"
+  fi
+
+  if [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
+    # grant further permissions to CES admin group via API
+    # TODO: Extract grant_permission_to_group_via_rest_api function from startup.sh into util.sh and use it instead
+    CES_ADMIN_GROUP=$(doguctl config --global admin_group)
+    DOGU_ADMIN_PASSWORD=$(doguctl config -e dogu_admin_password)
+    echo "Waiting for SonarQube to get up (max. ${WAIT_TIMEOUT} seconds)..."
+    wait_for_sonar_to_get_up "${WAIT_TIMEOUT}"
+    echo "Waiting for SonarQube to get healthy (max. ${WAIT_TIMEOUT} seconds)..."
+    wait_for_sonar_to_get_healthy ${WAIT_TIMEOUT} "${DOGU_ADMIN}" "${DOGU_ADMIN_PASSWORD}" ${CURL_LOG_LEVEL}
+    # grant profileadmin permission
+    curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=profileadmin&groupName=${CES_ADMIN_GROUP}"
+    # grant gateadmin permission
+    curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=gateadmin&groupName=${CES_ADMIN_GROUP}"
+    # grant provisioning permission
+    curl ${CURL_LOG_LEVEL} --fail -u "${DOGU_ADMIN}":"${DOGU_ADMIN_PASSWORD}" -X POST "http://localhost:9000/sonar/api/permissions/add_group?permission=provisioning&groupName=${CES_ADMIN_GROUP}"
+  fi
+
+
+  if [[ "${TO_MAJOR_VERSION}" -ge 8 ]] && [[ "${FROM_MAJOR_VERSION}" -lt 8 ]]; then
+    migrate_cas_identity_provider_in_db
+  fi
+
+
+  doguctl config post_upgrade_running false
+}
+
+# make the script only run when executed, not when sourced from bats tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_post_upgrade "$@"
+fi

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -3,22 +3,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-FROM_VERSION=
-TO_VERSION=
-FROM_MAJOR_VERSION=
-TO_MAJOR_VERSION=
-
-DATABASE_IP=postgresql
-DATABASE_USER=
-DATABASE_USER_PASSWORD=
-DATABASE_DB=
-
 function run_pre_upgrade() {
   FROM_VERSION="${1}"
   TO_VERSION="${2}"
   FROM_MAJOR_VERSION=$(echo "${FROM_VERSION}" | cut -d '.' -f1)
   TO_MAJOR_VERSION=$(echo "${TO_VERSION}" | cut -d '.' -f1)
 
+  DATABASE_IP=postgresql
   DATABASE_USER=$(doguctl config -e sa-postgresql/username)
   DATABASE_USER_PASSWORD=$(doguctl config -e sa-postgresql/password)
   DATABASE_DB=$(doguctl config -e sa-postgresql/database)

--- a/resources/upgrade-notification.sh
+++ b/resources/upgrade-notification.sh
@@ -1,22 +1,50 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail
 
-FROM_VERSION="${1}"
-TO_VERSION="${2}"
+CURRENT_MAX_MAP_COUNT=$(cat /proc/sys/vm/max_map_count)
 
-if [[ ${FROM_VERSION} == "5"* ]] || [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
-  echo "Upgrade from version ${FROM_VERSION} to ${TO_VERSION} is not supported. Please upgrade to version 6.7.7-2 before."
-  exit 1
-fi
+function run_upgrade_notification() {
+  FROM_VERSION="${1}"
+  TO_VERSION="${2}"
+  FROM_MAJOR_VERSION=$(echo "${FROM_VERSION}" | cut -d '.' -f1)
 
-if [[ ${FROM_VERSION} == "6.7."* ]] && [[ ${TO_VERSION} == "7.9."* ]]; then
-  echo "You are upgrading your SonarQube instance from 6.7.x LTS to 7.9.x LTS. Please consider backing up your SonarQube database. Upgrade problems are rare, but you'll want the backup if anything does happen."
-  echo "The currently installed plugins will be re-installed in SonarQube 7.9, potentially in a newer version than they are installed now. As not all plugins which have been available in SonarQube 6.7 are also available in SonarQube 7.9, you should check the log output for plugins which could not be re-installed. The plugin binaries from your current 6.7.x SonarQube instance will not be removed, but be moved to their own folder in the extensions volume."
-fi
+  if [[ ${FROM_VERSION} == "5"* ]] || [[ ${FROM_VERSION} == "6.7.6-1" ]]; then
+    echo "Upgrade from version ${FROM_VERSION} to ${TO_VERSION} is not supported. Please upgrade to version 6.7.7-2 before."
+    exit 1
+  fi
 
-if [[ $(cat /proc/sys/vm/max_map_count) -lt 262144 ]]; then
-  echo "Your max virtual memory areas vm.max_map_count is too low, increase to at least [262144]. You can do so by upgrading the ces-commons package to at least version 0.2.0."
-  exit 1
+  if [[ ${FROM_VERSION} == "6.7."* ]] && [[ ${TO_VERSION} == "7.9."* ]]; then
+    echo "You are upgrading your SonarQube instance from 6.7.x LTS to 7.9.x LTS. Please consider backing up your SonarQube database. Upgrade problems are rare, but you'll want the backup if anything does happen."
+    echo "The currently installed plugins will be re-installed in SonarQube 7.9, potentially in a newer version than they are installed now. As not all plugins which have been available in SonarQube 6.7 are also available in SonarQube 7.9, you should check the log output for plugins which could not be re-installed. The plugin binaries from your current 6.7.x SonarQube instance will not be removed, but be moved to their own folder in the extensions volume."
+  fi
+
+  if [[ ${CURRENT_MAX_MAP_COUNT} -lt 262144 ]]; then
+    echo "Your max virtual memory areas vm.max_map_count is too low, increase to at least [262144]. You can do so by upgrading the ces-commons package to at least version 0.2.0."
+    exit 1
+  fi
+
+  if [[ ${FROM_MAJOR_VERSION} -lt 7 ]] && [[ ${TO_VERSION} == "8.9."* ]]; then
+    echo "Upgrade from version ${FROM_VERSION} to ${TO_VERSION} is not supported. It is not safe to migrate between"
+    echo "several major versions in one step."
+    echo "Please follow the upgrade path of one major version to the next one instead."
+    exit 1
+  fi
+
+  if [[ ${FROM_VERSION} == "7.9."* ]] && [[ ${TO_VERSION} == "8.9."* ]]; then
+    echo "You are upgrading your SonarQube instance from 7.9.x LTS to 8.9.x LTS. Please consider backing up your SonarQube database."
+    echo "Upgrade problems are rare, but you may want backup in case anything goes wrong."
+    echo "Some plugins will be uninstalled because SonarQube 8.9 includes the plugin functionality into its core."
+    echo "Please check the SonarQube plugin compatibility in the release notes. Concerned plugins will move to"
+    echo "$(extensions/deprecated-plugins/) in case you need them."
+    echo "Please check the log output for plugins which could not be installed."
+  fi
+
+  return 0
+}
+
+# make the script only run when executed, not when sourced from bats tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_upgrade_notification "$@"
 fi

--- a/resources/upgrade-notification.sh
+++ b/resources/upgrade-notification.sh
@@ -37,14 +37,14 @@ function run_upgrade_notification() {
     echo "Upgrade problems are rare, but you may want backup in case anything goes wrong."
     echo "Some plugins will be uninstalled because SonarQube 8.9 includes the plugin functionality into its core."
     echo "Please check the SonarQube plugin compatibility in the release notes. Concerned plugins will move to"
-    echo "$(extensions/deprecated-plugins/) in case you need them."
+    echo "the sonar dogu volume extensions/deprecated-plugins/ in case you need them."
     echo "Please check the log output for plugins which could not be installed."
   fi
 
   return 0
 }
 
-# make the script only run when executed, not when sourced from bats tests)
+# make the script only run when executed, not when sourced from bats tests
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   run_upgrade_notification "$@"
 fi

--- a/unitTests/post-upgrade.bats
+++ b/unitTests/post-upgrade.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Bind an unbound BATS variable that fails all tests when combined with 'set -o nounset'
+export BATS_TEST_START_TIME="0"
+
+load '/workspace/target/bats_libs/bats-support/load.bash'
+load '/workspace/target/bats_libs/bats-assert/load.bash'
+load '/workspace/target/bats_libs/bats-mock/load.bash'
+
+setup() {
+  export SONARQUBE_HOME=/opt/sonar
+  export STARTUP_DIR=/workspace/resources/
+
+  # bats-mock/mock_create needs to be injected into the path so the production code will find the mock
+  doguctl="$(mock_create)"
+  psql="$(mock_create)"
+  curl="$(mock_create)"
+  jq="$(mock_create)"
+  export doguctl
+  export psql
+  ln -s "${doguctl}" "${BATS_TMPDIR}/doguctl"
+  ln -s "${psql}" "${BATS_TMPDIR}/psql"
+  ln -s "${curl}" "${BATS_TMPDIR}/curl"
+  ln -s "${jq}" "${BATS_TMPDIR}/jq"
+  export PATH="${PATH}:${BATS_TMPDIR}"
+}
+
+teardown() {
+  unset SONARQUBE_HOME
+  unset STARTUP_DIR
+  # bats-mock/mock_create needs to be injected into the path so the production code will find the mock
+  rm "${BATS_TMPDIR}/doguctl"
+  rm "${BATS_TMPDIR}/psql"
+  rm "${BATS_TMPDIR}/curl"
+  rm "${BATS_TMPDIR}/jq"
+}
+
+@test "run_post_upgrade should db-migrate for upgrade from 7.9.4-4 to 8.9.0-1" {
+  mock_set_status "${doguctl}" 0
+  mock_set_output "${doguctl}" "sql-username"
+  mock_set_output "${doguctl}" "sql-password"
+  mock_set_output "${doguctl}" "sql-database"
+  mock_set_status "${curl}" 0
+  mock_set_status "${jq}" 0
+
+  run /workspace/resources/post-upgrade.sh "7.9.4-4" "8.9.0-1"
+
+  assert_success
+  assert_line 'Running post-upgrade script...'
+  assert_line --partial 'Waiting for SonarQube status endpoint to be available'
+  assert_line --partial 'SonarQube status endpoint is available'
+  assert_line --partial 'Checking if db migration is needed'
+  assert_line --partial 'No db migration is needed'
+  refute_line --partial "Database migration is required"
+  refute_line --partial "Plugin"
+  assert_line 'Migrating DB: Update accounts associated with identity provider CAS to SonarQube...'
+  assert_equal "$(mock_get_call_num "${doguctl}")" "5"
+  assert_equal "$(mock_get_call_args "${doguctl}" "1")" "config -e sa-postgresql/username"
+  assert_equal "$(mock_get_call_args "${doguctl}" "2")" "config -e sa-postgresql/password"
+  assert_equal "$(mock_get_call_args "${doguctl}" "3")" "config -e sa-postgresql/database"
+  assert_equal "$(mock_get_call_args "${doguctl}" "4")" "wait-for-http --timeout 600 --method GET http://localhost:9000/sonar/api/system/status"
+  assert_equal "$(mock_get_call_args "${doguctl}" "5")" "config post_upgrade_running false"
+  assert_equal "$(mock_get_call_num "${psql}")" "1"
+}

--- a/unitTests/pre-upgrade.bats
+++ b/unitTests/pre-upgrade.bats
@@ -38,8 +38,8 @@ teardown() {
 
   assert_success
   assert_line 'Running pre-upgrade script...'
-  assert_line 'Removing obsolete plugins that now come with SonarQube 8...'
-  assert_line 'Finished removing obsolete plugins.'
+  assert_line 'Moving obsolete plugins that now come with SonarQube 8...'
+  assert_line 'Finished moving obsolete plugins.'
   assert_equal "$(mock_get_call_num "${doguctl}")" "4"
   assert_equal "$(mock_get_call_args "${doguctl}" "1")" "config -e sa-postgresql/username"
   assert_equal "$(mock_get_call_args "${doguctl}" "2")" "config -e sa-postgresql/password"

--- a/unitTests/upgrade-notification.bats
+++ b/unitTests/upgrade-notification.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Bind an unbound BATS variable that fails all tests when combined with 'set -o nounset'
+export BATS_TEST_START_TIME="0"
+
+load '/workspace/target/bats_libs/bats-support/load.bash'
+load '/workspace/target/bats_libs/bats-assert/load.bash'
+load '/workspace/target/bats_libs/bats-mock/load.bash'
+
+setup() {
+  export SONARQUBE_HOME=/opt/sonar
+  export STARTUP_DIR=/workspace/resources/
+}
+
+teardown() {
+  unset SONARQUBE_HOME
+  unset STARTUP_DIR
+}
+
+@test "run_upgrade_notification should fail for upgrade for unsupported 5.1.0-1 to 10.11.12-13" {
+  run /workspace/resources/upgrade-notification.sh "5.1.0-1" "10.11.12-13"
+
+  assert_failure
+  assert_line --partial 'Upgrade from version 5.1.0-1 to 10.11.12-13 is not supported'
+}
+
+@test "run_upgrade_notification should do fail for upgrade from specially unsupported version 6.7.6-1" {
+  run /workspace/resources/upgrade-notification.sh "6.7.6-1" "10.11.12-13"
+
+  assert_failure
+  assert_line --partial 'Upgrade from version 6.7.6-1 to 10.11.12-13 is not supported'
+}
+
+@test "run_upgrade_notification should fail for multi-hop upgrade from 6.7.6-1 to 8.9.0-1" {
+  run /workspace/resources/upgrade-notification.sh "6.7.6-1" "8.9.0-1"
+
+  assert_failure
+  assert_line --partial 'Upgrade from version 6.7.6-1 to 8.9.0-1 is not supported'
+}
+
+@test "run_upgrade_notification should maxMapCount-fail for upgrade from 6.7.7-1 to 7.9.2-3" {
+  run /workspace/resources/upgrade-notification.sh "6.7.7-1" "7.9.2-3"
+
+  assert_failure
+  assert_line --partial 'Your max virtual memory areas vm.max_map_count is too low'
+}
+
+@test "run_upgrade_notification should print notification from 6.7.7-1 to 7.9.2-3" {
+  # note the sequence of sourcing and overwriting the map count variable
+  source /workspace/resources/upgrade-notification.sh
+  export CURRENT_MAX_MAP_COUNT=9999999
+
+  actual=$(run_upgrade_notification "6.7.7-1" "7.9.2-3")
+
+  assert_equal $? 0
+  [[ "${actual}" =~ 'You are upgrading your SonarQube instance from 6.7.x LTS to 7.9.x LTS'* ]]
+}
+
+@test "run_upgrade_notification should print notification from 7.9.2-3 to 8.9.0-1" {
+  # note the sequence of sourcing and overwriting the map count variable
+  source /workspace/resources/upgrade-notification.sh
+  export CURRENT_MAX_MAP_COUNT=9999999
+
+  actual=$(run_upgrade_notification "7.9.2-3" "8.9.0-1")
+
+  assert_equal $? 0
+  [[ "${actual}" =~ 'You are upgrading your SonarQube instance from 7.9.x LTS to 8.9.x LTS'* ]]
+}
+
+


### PR DESCRIPTION
resolve #63 by db migration. Since there may already exist SQ instances with this problem, the DB migration is not excluded to a major upgrade. Instead all upgrades within the SQ version n8 range will apply. This migration is rather harmless because a very specific and small set of values will be changed.

Also this PR adds several shell tests and changes that enable tests in the first place.