### PR TITLE
Fix bootstrap error vm.max_map_count in k8s environments.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+export NAMESPACE=ecosystem

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ out/
 
 # ignore VS code stuff
 .vscode/*
+
+.target/
+.env
+.bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed elasticearch bootstrap error where `vm.max_map_count` is too low.
+  - Set `node.store.allow_mmap` to `false` and restrict the usage of `mmap` in k8s environments to avoid elasticsearch bootstrap error. This option is used to avoid usage of privileged containers.
 
 ## [v9.9.1-4] - 2023-06-05
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cloudogu.com/official/java:17.0.6-1 as BASE
+FROM registry.cloudogu.com/official/java:17.0.6-2 as base
 
 ENV SONARQUBE_HOME=/opt/sonar \
     # mark as webapp for nginx
@@ -7,7 +7,7 @@ ENV SONARQUBE_HOME=/opt/sonar \
     CAS_PLUGIN_VERSION=5.0.2 \
     STARTUP_DIR="/"
 
-FROM BASE as builder
+FROM base as builder
 
 ENV SONARQUBE_ZIP_SHA256=40bb45f551c7959ba1d3a5ff7b5432a558a5b2ad2efa5e9e1fcf52b83142897b \
     CAS_PLUGIN_JAR_SHA256=82f9fd7f65c9ce255f4f1dd6649a65a1f7eaf2acbc6a54f2c8103cbc2a42010f \
@@ -24,7 +24,7 @@ RUN rm sonarqube-${SONAR_VERSION}.zip
 RUN curl --fail --location "https://github.com/cloudogu/sonar-cas-plugin/releases/download/v${CAS_PLUGIN_VERSION}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar" --output "${BUILDER_HOME}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar"
 RUN echo "${CAS_PLUGIN_JAR_SHA256} *${BUILDER_HOME}/sonar-cas-plugin-${CAS_PLUGIN_VERSION}.jar" | sha256sum -c -
 
-FROM BASE
+FROM base
 
 LABEL NAME="official/sonar" \
     VERSION="9.9.1-4" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.64.1', 'github.com/cloudogu/dogu-build-lib@v2.1.0'])
+@Library(['github.com/cloudogu/ces-build-lib@1.65.0', 'github.com/cloudogu/dogu-build-lib@v2.1.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/build/make/bats.mk
+++ b/build/make/bats.mk
@@ -1,23 +1,17 @@
-MAKEFILES_VERSION=7.5.0
-.DEFAULT_GOAL:=dogu-release
-
 WORKSPACE=/workspace
 BATS_LIBRARY_DIR=$(TARGET_DIR)/bats_libs
-TESTS_DIR=./unitTests
+TESTS_DIR=$(WORKDIR)/batsTests
 BASH_TEST_REPORT_DIR=$(TARGET_DIR)/shell_test_reports
 BASH_TEST_REPORTS=$(BASH_TEST_REPORT_DIR)/TestReport-*.xml
 BATS_ASSERT=$(BATS_LIBRARY_DIR)/bats-assert
 BATS_MOCK=$(BATS_LIBRARY_DIR)/bats-mock
 BATS_SUPPORT=$(BATS_LIBRARY_DIR)/bats-support
+BATS_FILE=$(BATS_LIBRARY_DIR)/bats-file
 BATS_BASE_IMAGE?=bats/bats
 BATS_CUSTOM_IMAGE?=cloudogu/bats
 BATS_TAG?=1.2.1
-
-include build/make/variables.mk
-include build/make/self-update.mk
-include build/make/clean.mk
-include build/make/release.mk
-include build/make/k8s-dogu.mk
+BATS_DIR=build/make/bats
+BATS_WORKDIR="${WORKDIR}"/"${BATS_DIR}"
 
 .PHONY unit-test-shell:
 unit-test-shell: unit-test-shell-$(ENVIRONMENT)
@@ -31,35 +25,39 @@ $(BATS_MOCK):
 $(BATS_SUPPORT):
 	@git clone --depth 1 https://github.com/bats-core/bats-support $@
 
+$(BATS_FILE):
+	@git clone --depth 1 https://github.com/bats-core/bats-file $@
+
 $(BASH_SRC):
 	BASH_SRC:=$(shell find "${WORKDIR}" -type f -name "*.sh")
 
 ${BASH_TEST_REPORT_DIR}: $(TARGET_DIR)
 	@mkdir -p $(BASH_TEST_REPORT_DIR)
 
-unit-test-shell-ci: $(BASH_SRC) $(BASH_TEST_REPORT_DIR) $(BATS_ASSERT) $(BATS_MOCK) $(BATS_SUPPORT)
+unit-test-shell-ci: $(BASH_SRC) $(BASH_TEST_REPORT_DIR) $(BATS_ASSERT) $(BATS_MOCK) $(BATS_SUPPORT) $(BATS_FILE)
 	@echo "Test shell units on CI server"
 	@make unit-test-shell-generic
 
-unit-test-shell-local: $(BASH_SRC) $(PASSWD) $(ETCGROUP) $(HOME_DIR) buildTestImage $(BASH_TEST_REPORT_DIR) $(BATS_ASSERT) $(BATS_MOCK) $(BATS_SUPPORT)
+unit-test-shell-local: $(BASH_SRC) $(PASSWD) $(ETCGROUP) $(HOME_DIR) buildTestImage $(BASH_TEST_REPORT_DIR) $(BATS_ASSERT) $(BATS_MOCK) $(BATS_SUPPORT) $(BATS_FILE)
 	@echo "Test shell units locally (in Docker)"
 	@docker run --rm \
-		-u "$(UID_NR):$(GID_NR)" \
-		-v $(PASSWD):/etc/passwd:ro \
 		-v $(HOME_DIR):/home/$(USER) \
 		-v $(WORKDIR):$(WORKSPACE) \
 		-w $(WORKSPACE) \
 		--entrypoint="" \
 		$(BATS_CUSTOM_IMAGE):$(BATS_TAG) \
-		${TESTS_DIR}/customBatsEntrypoint.sh make unit-test-shell-generic
+		"${BATS_DIR}"/customBatsEntrypoint.sh make unit-test-shell-generic-no-junit
 
 unit-test-shell-generic:
 	@bats --formatter junit --output ${BASH_TEST_REPORT_DIR} ${TESTS_DIR}
 
+unit-test-shell-generic-no-junit:
+	@bats ${TESTS_DIR}
+
 .PHONY buildTestImage:
 buildTestImage:
 	@echo "Build shell test container"
-	@cd ${TESTS_DIR} && docker build \
+	@cd $(BATS_WORKDIR) && docker build \
 		--build-arg=BATS_BASE_IMAGE=${BATS_BASE_IMAGE} \
 		--build-arg=BATS_TAG=${BATS_TAG} \
 		-t ${BATS_CUSTOM_IMAGE}:${BATS_TAG} \

--- a/build/make/bats/Dockerfile
+++ b/build/make/bats/Dockerfile
@@ -1,0 +1,7 @@
+ARG BATS_BASE_IMAGE
+ARG BATS_TAG
+
+FROM ${BATS_BASE_IMAGE}:${BATS_TAG}
+
+# Make bash more findable by scripts and tests
+RUN apk add make git bash

--- a/build/make/bats/customBatsEntrypoint.sh
+++ b/build/make/bats/customBatsEntrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+"$@"

--- a/build/make/k8s-controller.mk
+++ b/build/make/k8s-controller.mk
@@ -55,7 +55,7 @@ build-controller: ${SRC} compile ## Builds the controller Go binary.
 # Allows to perform tasks before locally running the controller
 K8S_RUN_PRE_TARGETS ?=
 .PHONY: run
-run: manifests generate vet $(K8S_RUN_PRE_TARGETS) ## Run a controller from your host.
+run: manifests generate $(K8S_RUN_PRE_TARGETS) ## Run a controller from your host.
 	go run -ldflags "-X main.Version=$(VERSION)" ./main.go
 
 ##@ K8s - Integration test with envtest
@@ -64,7 +64,7 @@ $(K8S_INTEGRATION_TEST_DIR):
 	@mkdir -p $@
 
 .PHONY: k8s-integration-test
-k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate vet envtest ## Run k8s integration tests.
+k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate envtest ## Run k8s integration tests.
 	@echo "Running K8s integration tests..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -tags=k8s_integration ./... -coverprofile ${K8S_INTEGRATION_TEST_DIR}/report-k8s-integration.out
 
@@ -72,7 +72,7 @@ k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate vet envtest
 
 # The pre generation script creates a K8s resource yaml containing generated manager yaml.
 .PHONY: k8s-create-temporary-resource
- k8s-create-temporary-resource: ${TARGET_DIR} manifests kustomize
+ k8s-create-temporary-resource: $(K8S_RESOURCE_TEMP_FOLDER) manifests kustomize
 	@echo "Generating temporary k8s resources $(K8S_RESOURCE_TEMP_YAML)..."
 	cd $(WORKDIR)/config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
 	$(KUSTOMIZE) build config/default > $(K8S_RESOURCE_TEMP_YAML)
@@ -83,12 +83,12 @@ k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate vet envtest
 CONTROLLER_GEN = $(UTILITY_BIN_PATH)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3)
 
 KUSTOMIZE = $(UTILITY_BIN_PATH)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.7)
 
 ENVTEST = $(UTILITY_BIN_PATH)/setup-envtest
 .PHONY: envtest

--- a/build/make/k8s-dogu.mk
+++ b/build/make/k8s-dogu.mk
@@ -1,18 +1,16 @@
-
 # Variables
-
 # Path to the dogu json of the dogu
 DOGU_JSON_FILE=$(WORKDIR)/dogu.json
 DOGU_JSON_DEV_FILE=${TARGET_DIR}/dogu.json
 # Name of the dogu is extracted from the dogu.json
-ARTIFACT_ID=$(shell yq -e ".Name" $(DOGU_JSON_FILE) | sed "s|.*/||g")
+ARTIFACT_ID=$(shell $(BINARY_YQ) -e ".Name" $(DOGU_JSON_FILE) | sed "s|.*/||g")
 # Namespace of the dogu is extracted from the dogu.json
-ARTIFACT_NAMESPACE=$(shell yq -e ".Name" $(DOGU_JSON_FILE) | sed "s|/.*||g")
+ARTIFACT_NAMESPACE=$(shell $(BINARY_YQ) -e ".Name" $(DOGU_JSON_FILE) | sed "s|/.*||g")
 # Namespace of the dogu is extracted from the dogu.json
-VERSION=$(shell yq -e ".Version" $(DOGU_JSON_FILE))
+VERSION=$(shell $(BINARY_YQ) -e ".Version" $(DOGU_JSON_FILE))
 # Image of the dogu is extracted from the dogu.json
-IMAGE=$(shell yq -e ".Image" $(DOGU_JSON_FILE)):$(VERSION)
-IMAGE_DEV_WITHOUT_TAG=$(shell yq -e ".Image" $(DOGU_JSON_FILE) | sed "s|registry\.cloudogu\.com\(.\+\)|${K3CES_REGISTRY_URL_PREFIX}\1|g")
+IMAGE=$(shell $(BINARY_YQ) -e ".Image" $(DOGU_JSON_FILE)):$(VERSION)
+IMAGE_DEV_WITHOUT_TAG=$(shell $(BINARY_YQ) -e ".Image" $(DOGU_JSON_FILE) | sed "s|registry\.cloudogu\.com\(.\+\)|${K3CES_REGISTRY_URL_PREFIX}\1|g")
 IMAGE_DEV=${IMAGE_DEV_WITHOUT_TAG}:${VERSION}
 
 include $(WORKDIR)/build/make/k8s.mk
@@ -30,7 +28,7 @@ K8S_RESOURCE_PRODUCTIVE_YAML ?= $(K8S_RESOURCE_PRODUCTIVE_FOLDER)/$(ARTIFACT_ID)
 K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 # The pre generation script creates a k8s resource yaml containing the dogu crd and the content from the k8s folder.
 .PHONY: k8s-create-temporary-resource
- k8s-create-temporary-resource: $(TARGET_DIR) $(K8S_RESOURCE_TEMP_FOLDER)
+ k8s-create-temporary-resource: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER)
 	@echo "Generating temporary K8s resources $(K8S_RESOURCE_TEMP_YAML)..."
 	@rm -f $(K8S_RESOURCE_TEMP_YAML)
 	@sed "s|NAMESPACE|$(ARTIFACT_NAMESPACE)|g" $(K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML) | sed "s|NAME|$(ARTIFACT_ID)|g"  | sed "s|VERSION|$(VERSION)|g" >> $(K8S_RESOURCE_TEMP_YAML)
@@ -39,8 +37,8 @@ K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 ##@ K8s - Dogu
 
 .PHONY: install-dogu-descriptor
-install-dogu-descriptor: $(TARGET_DIR) ## Installs a configmap with current dogu.json into the cluster.
+install-dogu-descriptor: ${BINARY_YQ} $(TARGET_DIR) ## Installs a configmap with current dogu.json into the cluster.
 	@echo "Generate configmap from dogu.json..."
-	@jq ".Image=\"${IMAGE_DEV_WITHOUT_TAG}\"" ${DOGU_JSON_FILE} > ${DOGU_JSON_DEV_FILE}
-	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f -
+	@$(BINARY_YQ) ".Image=\"${IMAGE_DEV_WITHOUT_TAG}\"" ${DOGU_JSON_FILE} > ${DOGU_JSON_DEV_FILE}
+	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f - --namespace=${NAMESPACE}
 	@echo "Done."

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -8,8 +8,6 @@ endif
 
 BINARY_YQ = $(UTILITY_BIN_PATH)/yq
 
-# The cluster root variable is used to the build images to the cluster. It can be defined in a .myenv file.
-K8S_CLUSTER_ROOT ?=
 # The productive tag of the image
 IMAGE ?=
 
@@ -22,17 +20,14 @@ K3CES_REGISTRY_URL_PREFIX="${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}"
 K8S_RESOURCE_TEMP_FOLDER ?= $(TARGET_DIR)/make/k8s
 K8S_RESOURCE_TEMP_YAML ?= $(K8S_RESOURCE_TEMP_FOLDER)/$(ARTIFACT_ID)_$(VERSION).yaml
 
-# The current namespace is extracted from the current context.
-K8S_CURRENT_NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..namespace}')
-
 ##@ K8s - Variables
 
 .PHONY: check-all-vars
-check-all-vars: check-k8s-cluster-root-env-var check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry ## Conduct a sanity check against selected build artefacts or local environment
+check-all-vars: check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry check-k8s-namespace-env-var ## Conduct a sanity check against selected build artefacts or local environment
 
-.PHONY: check-k8s-cluster-root-env-var
-check-k8s-cluster-root-env-var:
-	@$(call check_defined, K8S_CLUSTER_ROOT, root path of your k3ces)
+.PHONY: check-k8s-namespace-env-var
+check-k8s-namespace-env-var:
+	@$(call check_defined, NAMESPACE, k8s namespace)
 
 .PHONY: check-k8s-image-env-var
 check-k8s-image-env-var:
@@ -60,7 +55,7 @@ ${K8S_RESOURCE_TEMP_FOLDER}:
 .PHONY: k8s-delete
 k8s-delete: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Deletes all dogu related resources from the K8s cluster.
 	@echo "Delete old dogu resources..."
-	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true
+	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true --namespace=${NAMESPACE}
 
 # The additional targets executed after the generate target, executed before each apply and delete. The generate target
 # produces a temporary yaml. This yaml is accessible via K8S_RESOURCE_TEMP_YAML an can be changed before the apply/delete.
@@ -71,14 +66,14 @@ K8S_PRE_GENERATE_TARGETS ?= k8s-create-temporary-resource
 .PHONY: k8s-generate
 k8s-generate: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER) $(K8S_PRE_GENERATE_TARGETS) ## Generates the final resource yaml.
 	@echo "Applying general transformations..."
-	@sed -i "s/'{{ .Namespace }}'/$(K8S_CURRENT_NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
+	@sed -i "s/'{{ .Namespace }}'/$(NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
 	@$(BINARY_YQ) -i e "(select(.kind == \"Deployment\").spec.template.spec.containers[]|select(.image == \"*$(ARTIFACT_ID)*\").image)=\"$(IMAGE_DEV)\"" $(K8S_RESOURCE_TEMP_YAML)
 	@echo "Done."
 
 .PHONY: k8s-apply
 k8s-apply: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Applies all generated K8s resources to the current cluster and namespace.
 	@echo "Apply generated K8s resources..."
-	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML)
+	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML) --namespace=${NAMESPACE}
 
 ##@ K8s - Docker
 

--- a/build/make/mockery.yaml
+++ b/build/make/mockery.yaml
@@ -1,0 +1,4 @@
+inpackage: True
+testonly: True
+with-expecter: True
+keeptree: False

--- a/build/make/mocks.mk
+++ b/build/make/mocks.mk
@@ -1,0 +1,27 @@
+##@ Mocking
+
+MOCKERY_BIN=${UTILITY_BIN_PATH}/mockery
+MOCKERY_VERSION=v2.20.0
+MOCKERY_YAML=${WORKDIR}/.mockery.yaml
+
+${MOCKERY_BIN}: ${UTILITY_BIN_PATH}
+	$(call go-get-tool,$(MOCKERY_BIN),github.com/vektra/mockery/v2@$(MOCKERY_VERSION))
+
+${MOCKERY_YAML}:
+	@cp ${WORKDIR}/build/make/mockery.yaml ${WORKDIR}/.mockery.yaml
+
+.PHONY: mocks
+mocks: ${MOCKERY_BIN} ${MOCKERY_YAML} ## This target is used to generate mocks for all interfaces in a project.
+	@for dir in ${WORKDIR}/*/ ;\
+ 		do \
+ 		# removes trailing '/' \
+		dir=$${dir%*/} ;\
+		# removes everything before the last '/' \
+		dir=$${dir##*/} ;\
+		if ! echo '${MOCKERY_IGNORED}' | egrep -q "\b$${dir}\b" ;\
+		then \
+		  	echo "Creating mocks for $${dir}" ;\
+			${MOCKERY_BIN} --all --dir $${dir} ;\
+		fi ;\
+ 	done ;
+	@echo "Mocks successfully created."

--- a/build/make/test-integration.mk
+++ b/build/make/test-integration.mk
@@ -6,6 +6,7 @@ INTEGRATION_TEST_LOG=$(INTEGRATION_TEST_DIR)/integration-tests.log
 INTEGRATION_TEST_REPORT=$(INTEGRATION_TEST_DIR)/coverage.out
 PRE_INTEGRATIONTESTS?=start-local-docker-compose
 POST_INTEGRATIONTESTS?=stop-local-docker-compose
+INTEGRATION_TEST_NAME_PATTERN?=.*
 
 .PHONY: integration-test
 integration-test: $(XUNIT_INTEGRATION_XML) ## Start integration tests
@@ -35,15 +36,9 @@ ifneq ($(strip $(PRE_INTEGRATIONTESTS)),)
 endif
 
 	@mkdir -p $(INTEGRATION_TEST_DIR)
-	@echo 'mode: set' > ${INTEGRATION_TEST_REPORT}
+	@echo 'mode: set' > $(INTEGRATION_TEST_REPORT)
 	@rm -f $(INTEGRATION_TEST_LOG) || true
-	@for PKG in $(PACKAGES_FOR_INTEGRATION_TEST) ; do \
-    ${GO_CALL} test -tags=${GO_BUILD_TAG_INTEGRATION_TEST} -v $$PKG -coverprofile=${INTEGRATION_TEST_REPORT}.tmp 2>&1 | tee $(INTEGRATION_TEST_LOG).tmp ; \
-		cat ${INTEGRATION_TEST_REPORT}.tmp | tail +2 >> ${INTEGRATION_TEST_REPORT} ; \
-		rm -f ${INTEGRATION_TEST_REPORT}.tmp ; \
-		cat $(INTEGRATION_TEST_LOG).tmp >> $(INTEGRATION_TEST_LOG) ; \
-		rm -f $(INTEGRATION_TEST_LOG).tmp ; \
-	done
+	@$(GO_CALL) test ./... -v -tags=${GO_BUILD_TAG_INTEGRATION_TEST} -coverpkg=./... -coverprofile=${INTEGRATION_TEST_REPORT} -run ${INTEGRATION_TEST_NAME_PATTERN} 2>&1 | tee $(INTEGRATION_TEST_LOG)
 	@cat $(INTEGRATION_TEST_LOG) | $(GO_JUNIT_REPORT) > $@
 	@if grep '^FAIL' $(INTEGRATION_TEST_LOG); then \
 		exit 1; \

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -15,12 +15,11 @@ GO_ENVIRONMENT?=
 # GO_CALL accomodates the go CLI command as well as necessary environment variables which are optional.
 GO_CALL=${GO_ENVIRONMENT} go
 PACKAGES=$(shell ${GO_CALL} list ./... | grep -v /vendor/)
-PACKAGES_FOR_INTEGRATION_TEST?=${PACKAGES}
 GO_BUILD_TAG_INTEGRATION_TEST?=integration
 GOMODULES=on
 UTILITY_BIN_PATH?=${WORKDIR}/.bin
 
-SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "./vendor/*")
+SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "*/vendor/*")
 
 # debian stuff
 DEBIAN_BUILD_DIR=$(BUILD_DIR)/deb
@@ -63,6 +62,10 @@ $(ETCGROUP): $(TMP_DIR)
 
 $(UTILITY_BIN_PATH):
 	@mkdir -p $@
+
+# Subdirectories of workdir where no mocks should be generated.
+# Multiple directories can be separated by space, comma or whatever is not a word to regex.
+MOCKERY_IGNORED=vendor,build,docs
 
 ##@ General
 

--- a/resources/opt/sonar/conf/sonar.properties.tpl
+++ b/resources/opt/sonar/conf/sonar.properties.tpl
@@ -211,7 +211,13 @@ sonar.web.context=/sonar
 # -XX:+HeapDumpOnOutOfMemoryError
 
 # Same as previous property, but allows to not repeat all other settings like -Xmx
+{{ if .Env.Get "POD_NAMESPACE" }}
+# In k8s environments we restrict the usage of mmap, because running privileged containers (to vm.max_map_count kernel setting)
+# is not possible in all environments.
+sonar.search.javaAdditionalOpts=-Dnode.store.allow_mmap=false,-Dlog4j2.formatMsgNoLookups=true
+{{ else }}
 sonar.search.javaAdditionalOpts=-Dlog4j2.formatMsgNoLookups=true
+{{ end }}
 
 # Elasticsearch port. Default is 9001. Use 0 to get a free port.
 # As a security precaution, should be blocked by a firewall and not exposed to the Internet.


### PR DESCRIPTION
Set `node.store.allow_mmap` to `false` and restrict the usage of `mmap` in k8s environments to avoid elasticsearch bootstrap error. This option is used to avoid usage of privileged containers.

Resolves #90 