### PR TITLE
#151 Fix accidentally authenticated /batch endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#146] Update base image to v21.0.5-1
 
 ### Fixed
-- [#144] Handle unauthenticated api request properly
+- [#144] Handle unauthenticated API request properly
+- [#151] Make remove the need for authentication for the API endpoint `/sonar/batch`
+  - default maven sonar goals must use the property `-Dsonar.token` to avoid `HTTP 401 Unauthenticated` results as `-Dsonar.login` is deprecated
 
 ## [v25.1.0-6] - 2025-10-22
 ### Added

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -7,7 +7,8 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 ## [Unreleased]
 ### Geändert
 * Das Dogu bietet nun die SonarQube-Version 2025.10 (LTS) an. Die Release Notes von SonarQube finden Sie [hier](https://docs.sonarsource.com/sonarqube-community-build/server-update-and-maintenance/release-notes#latest-release-25.10.0.114319).
-* Bugfix für die Navigation im Browser obwohl der User bereits abgemeldet ist.
+* Bugfix für die Navigation im Browser obwohl der User bereits abgemeldet ist. 
+* Dieses Release behebt Fehler für SonarQube-Scans mit Maven (ohne Community-Branch-Plugin).
 
 ## [v25.1.0-6] - 2025-10-22
 * Eine Validierung wurde hinzugefügt, mit der nur Upgrades von Version 9 zu 25 möglich sind.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -7,6 +7,7 @@ Technical details on a release can be found in the corresponding [Changelog](htt
 ## [Unreleased]
 * The Dogu now offers SonarQube version 2025.1 (LTS). The SonarQube release notes can be found [here](https://docs.sonarsource.com/sonarqube-community-build/server-update-and-maintenance/release-notes#latest-release-25.10.0.114319).
 * Bug fix for navigation in the browser even though the user is already logged out.
+* This release removes a defect while executing SonarQube scans with Maven (without Community Branch plugin).
 
 ## [v25.1.0-6] - 2025-10-22
 * Validation has been added to allow only upgrades from version 9 to 25.

--- a/resources/carp.yml.tpl
+++ b/resources/carp.yml.tpl
@@ -58,7 +58,7 @@ log-level: "{{ .Config.GetOrDefault "logging/root" "WARN" }}"
 application-exec-command: "{{ .Env.Get "carpExecCommand" }}"
 
 # carp-resource-paths accepts a list of regular expressions of SonarQube routes that do not need authorization.
-# For security reasons, here usually appear static resources like CSS files etc.
+# For security reasons, here usually appear static resources like CSS files etc., anything that will appear WITHOUT authentication.
 # example: /sonar/css/ matches all requests that start with this path
 # Note: A misconfiguration could lead to undesirable exposing of authenticated
 # information.
@@ -68,6 +68,7 @@ carp-resource-paths:
   - /sonar/fonts/
   - /sonar/images/
   - /sonar/js/
+  - /sonar/batch/
 
 # Throttling
 #

--- a/sonarcarp/carp.yml
+++ b/sonarcarp/carp.yml
@@ -58,7 +58,7 @@ log-level: "DEBUG"
 application-exec-command: "sleep infinity"
 
 # carp-resource-paths accepts a list of regular expressions of SonarQube routes that do not need authorization.
-# For security reasons, here usually appear static resources like CSS files etc.
+# For security reasons, here usually appear static resources like CSS files etc., anything that will appear WITHOUT authentication.
 # example: /sonar/css/ matches all requests that start with this path
 # Note: A misconfiguration could lead to undesirable exposing of authenticated
 # information.
@@ -68,6 +68,7 @@ carp-resource-paths:
   - /sonar/fonts/
   - /sonar/images/
   - /sonar/js/
+  - /sonar/batch/
 
 # Throttling
 #


### PR DESCRIPTION
While being an internal API, `/batch` provides only GET endpoints for .jar downloads. I understand, these .jars are used to commence with the sonarqube scanning during maven calls. So it is okay to have these endpoints unauthenticated.

This PR resolves #151 